### PR TITLE
(splash) Replace CircularCheckBox with Checkbox

### DIFF
--- a/lib/pages/splash/splash_page.dart
+++ b/lib/pages/splash/splash_page.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'package:circular_check_box/circular_check_box.dart';
 import 'package:country_pickers/country.dart';
 import 'package:country_pickers/country_pickers.dart';
 import 'package:file_picker/file_picker.dart';
@@ -293,7 +292,7 @@ class _SplashPageState extends State<SplashPage> {
                                         maxWidth: 44,
                                         maxHeight: 44,
                                       ),
-                                      child: CircularCheckBox(
+                                      child: Checkbox(
                                         value: userlangCheck,
                                         materialTapTargetSize:
                                             MaterialTapTargetSize.padded,
@@ -370,7 +369,7 @@ class _SplashPageState extends State<SplashPage> {
                                         maxWidth: 44,
                                         maxHeight: 44,
                                       ),
-                                      child: CircularCheckBox(
+                                      child: Checkbox(
                                         value: globalCheck,
                                         materialTapTargetSize:
                                             MaterialTapTargetSize.padded,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,13 +197,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
-  circular_check_box:
-    dependency: "direct main"
-    description:
-      name: circular_check_box
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
   cli_util:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,6 @@ dependencies:
   cached_network_image: ^3.0.0
   carousel_slider: ^2.3.4
   charts_flutter:
-  circular_check_box: ^1.0.4
   convert:
   country_pickers: ^2.0.0
   crypto:


### PR DESCRIPTION
`CircularCheckBox` is broken because in recent Flutter versions `RenderToggleable` does not exist any more.