### PR TITLE
(dart) Disable publishing explicitly

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,8 @@ description: A new Flutter project.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.10.1+0
 
+publish_to: none
+
 environment:
   sdk: ">=2.10.0 <3.0.0"
 


### PR DESCRIPTION
Dart analysis complained following:

> warning: Publishable packages can't have git dependencies.
> (invalid_dependency at [violet] pubspec.yaml:49)

----

Recently the 'pubspec.yaml' of a new Flutter project generated by Android Studio automatically/initially contains the content in this patch.