### PR TITLE
(afterloading) Override dispose method properly

### DIFF
--- a/lib/pages/after_loading/afterloading_page.dart
+++ b/lib/pages/after_loading/afterloading_page.dart
@@ -51,7 +51,7 @@ class AfterLoadingPageState extends State<AfterLoadingPage>
   }
 
   @override
-  void disposed() {
+  void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }


### PR DESCRIPTION
Strictly this is a potential resource leak problem but effectively this is not meaningful.

This removes a hint of Dart analysis.