### PR TITLE
(afterloading) Remove blur effect code, not in use

### DIFF
--- a/lib/pages/after_loading/afterloading_page.dart
+++ b/lib/pages/after_loading/afterloading_page.dart
@@ -31,31 +31,6 @@ class AfterLoadingPageState extends State<AfterLoadingPage>
   PageController _c = PageController(initialPage: defaultInitialPage);
   int get _currentPage => _c.hasClients ? _c.page.round() : defaultInitialPage;
 
-  bool isBlurred = false;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-  }
-
-  @override
-  Future<void> didChangeAppLifecycleState(AppLifecycleState state) async {
-    setState(() {
-      if (state == AppLifecycleState.paused ||
-          state == AppLifecycleState.inactive)
-        isBlurred = true;
-      else
-        isBlurred = false;
-    });
-  }
-
-  @override
-  void disposed() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     if (!Settings.useDrawer)


### PR DESCRIPTION
In fact, applying blur effect or some screen change to paused or inactive state app may not be meaningful.