### PR TITLE
fix(hitomi): fix image route rule

### DIFF
--- a/lib/component/hitomi/hitomi.dart
+++ b/lib/component/hitomi/hitomi.dart
@@ -42,10 +42,10 @@ class HitomiManager {
       var x = int.tryParse('${postfix[0]}${postfix[1]}', radix: 16);
 
       if (x != null && !x.isNaN) {
-        var nf = 3;
-        if (x < 0x70) nf = 2;
-        if (x < 0x49) x = 1;
-        subdomainx = String.fromCharCode(97 + (x % nf));
+        var o = 0;
+        if (x < 0x80) o = 1;
+        if (x < 0x40) o = 2;
+        subdomainx = String.fromCharCode(97 + o);
       }
 
       if (rr['haswebp'] == 0 || rr['haswebp'] == null) {


### PR DESCRIPTION
https://ltn.hitomi.la/common.js was changed

It seems that the ``number_of_frontends`` variable and ``subdomain_from_galleryid`` function are no longer used.

And the ``rewrite_tn_paths`` function was added.(But, not include in this PR)