### PR TITLE
dart: use Dart 2.17 and fix Dart Analysis issues caused by updating

### DIFF
--- a/lib/pages/viewer/others/scrollable_positioned_list/src/wrapping.dart
+++ b/lib/pages/viewer/others/scrollable_positioned_list/src/wrapping.dart
@@ -120,7 +120,7 @@ class CustomRenderShrinkWrappingViewport extends CustomRenderViewport {
   /// contents.
   ///
   /// The [offset] must be specified. For testing purposes, consider passing a
-  /// [new ViewportOffset.zero] or [new ViewportOffset.fixed].
+  /// [ViewportOffset.zero] or [ViewportOffset.fixed].
   CustomRenderShrinkWrappingViewport({
     AxisDirection axisDirection = AxisDirection.down,
     required AxisDirection crossAxisDirection,
@@ -651,7 +651,7 @@ abstract class CustomRenderViewport
   /// list, if any, is used.
   ///
   /// The [offset] must be specified. For testing purposes, consider passing a
-  /// [new ViewportOffset.zero] or [new ViewportOffset.fixed].
+  /// [ViewportOffset.zero] or [ViewportOffset.fixed].
   CustomRenderViewport({
     AxisDirection axisDirection = AxisDirection.down,
     required AxisDirection crossAxisDirection,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ version: 1.28.0+0
 publish_to: none
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Dart 2.17 includes useful features such as enhanced enums. And `pubspec.lock` is already using the 2.17 version.