### PR TITLE
Need format before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
 
   ios-build:
     runs-on: macos-latest
+    needs: [ format ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -94,6 +95,7 @@ jobs:
 
   android-build:
     runs-on: ubuntu-latest
+    needs: [ format ]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This will applied to 
- Do not build when format is failed (to solve (workflow waiting problem by workflow was not cancelled by format fail))
- Do build after format has success