### PR TITLE
flutter: use PopScope instead of deprecated WillPopScope

### DIFF
--- a/lib/pages/after_loading/afterloading_page.dart
+++ b/lib/pages/after_loading/afterloading_page.dart
@@ -309,9 +309,14 @@ class AfterLoadingPageState extends State<AfterLoadingPage>
     Variables.updatePadding((mediaQuery.padding + mediaQuery.viewInsets).top,
         (mediaQuery.padding + mediaQuery.viewInsets).bottom);
 
-    return WillPopScope(
-      onWillPop: () async {
-        DateTime now = DateTime.now();
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (bool didPop) async {
+        if (didPop) {
+          return;
+        }
+
+        final now = DateTime.now();
 
         if (_lastPopAt != null &&
             now.difference(_lastPopAt!) <= const Duration(seconds: 2)) {
@@ -319,24 +324,22 @@ class AfterLoadingPageState extends State<AfterLoadingPage>
             await PlatformMiscMethods.instance.finishMainActivity();
           }
 
-          return true;
+          Navigator.of(context).pop();
+        } else {
+          _lastPopAt = now;
+
+          fToast.showToast(
+            child: ToastWrapper(
+              isCheck: false,
+              isWarning: true,
+              icon: Icons.logout,
+              msg: Translations.of(context).trans('closedoubletap'),
+            ),
+            ignorePointer: true,
+            gravity: ToastGravity.BOTTOM,
+            toastDuration: const Duration(seconds: 4),
+          );
         }
-
-        _lastPopAt = now;
-
-        fToast.showToast(
-          child: ToastWrapper(
-            isCheck: false,
-            isWarning: true,
-            icon: Icons.logout,
-            msg: Translations.of(context).trans('closedoubletap'),
-          ),
-          ignorePointer: true,
-          gravity: ToastGravity.BOTTOM,
-          toastDuration: const Duration(seconds: 4),
-        );
-
-        return false;
       },
       child: Scaffold(
         bottomNavigationBar: _usesBottomNavigationBar

--- a/lib/pages/lock/lock_screen.dart
+++ b/lib/pages/lock/lock_screen.dart
@@ -150,10 +150,8 @@ class _LockScreenState extends State<LockScreen> with TickerProviderStateMixin {
       ),
     );
 
-    return WillPopScope(
-      onWillPop: () async {
-        return widget.isRegisterMode;
-      },
+    return PopScope(
+      canPop: widget.isRegisterMode,
       child: page,
     );
   }

--- a/lib/pages/main/info/lab/artist_search/tag_group_modify.dart
+++ b/lib/pages/main/info/lab/artist_search/tag_group_modify.dart
@@ -5,12 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:uuid/uuid.dart';
+import 'package:violet/locale/locale.dart' as trans;
 import 'package:violet/other/dialogs.dart';
 import 'package:violet/pages/main/info/lab/artist_search/tag_group_modify_controller.dart';
 import 'package:violet/pages/segment/card_panel.dart';
 import 'package:violet/pages/settings/tag_selector.dart';
 import 'package:violet/settings/settings.dart';
-import 'package:violet/locale/locale.dart' as trans;
 
 class TagGroupModify extends StatefulWidget {
   final Map<String, int> tagGroup;
@@ -40,8 +40,8 @@ class _TagGroupModifyState extends State<TagGroupModify> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async => false,
+    return PopScope(
+      canPop: false,
       child: CardPanel.build(
         context,
         enableBackgroundColor: true,

--- a/lib/pages/settings/db_rebuild_page.dart
+++ b/lib/pages/settings/db_rebuild_page.dart
@@ -30,10 +30,8 @@ class _DBRebuildPagePageState extends State<DBRebuildPage> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        return false;
-      },
+    return PopScope(
+      canPop: false,
       child: Container(
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(1)),

--- a/lib/pages/settings/import_from_eh.dart
+++ b/lib/pages/settings/import_from_eh.dart
@@ -27,10 +27,8 @@ class _ImportFromEHPageState extends State<ImportFromEHPage> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        return false;
-      },
+    return PopScope(
+      canPop: false,
       child: Container(
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(1)),

--- a/lib/pages/settings/restore_bookmark.dart
+++ b/lib/pages/settings/restore_bookmark.dart
@@ -138,10 +138,8 @@ class _RestoreBookmarkPageState extends State<RestoreBookmarkPage> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        return false;
-      },
+    return PopScope(
+      canPop: false,
       child: Container(
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(1)),

--- a/lib/pages/settings/tag_rebuild_page.dart
+++ b/lib/pages/settings/tag_rebuild_page.dart
@@ -35,10 +35,8 @@ class _TagRebuildPageState extends State<TagRebuildPage> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        return false;
-      },
+    return PopScope(
+      canPop: false,
       child: Container(
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(1)),

--- a/lib/pages/viewer/viewer_controller.dart
+++ b/lib/pages/viewer/viewer_controller.dart
@@ -2,6 +2,7 @@
 // Copyright (C) 2020-2024. violet-team. Licensed under the Apache-2.0 License.
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
@@ -26,7 +27,7 @@ class ViewerController extends GetxController {
   late final int maxPage;
 
   /// viewer callbacks
-  late Function close;
+  late AsyncCallback close;
   late Function replace;
   late Function stopTimer;
   late Function startTimer;

--- a/lib/pages/viewer/viewer_page.dart
+++ b/lib/pages/viewer/viewer_page.dart
@@ -102,8 +102,9 @@ class _ViewerPageState extends State<ViewerPage> {
       );
     }
 
-    return WillPopScope(
-      onWillPop: _close,
+    return PopScope(
+      canPop: true,
+      onPopInvoked: _handlePopInvoked,
       child: body,
     );
   }
@@ -223,10 +224,13 @@ class _ViewerPageState extends State<ViewerPage> {
     if (Platform.isAndroid) _setupVolume();
   }
 
-  Future<bool> _close() async {
+  Future<void> _close() async {
     c.onSession.value = false;
     await _savePageRead();
-    return Future(() => true);
+  }
+
+  Future<void> _handlePopInvoked(bool didPop) async {
+    await _close();
   }
 
   _setupVolume() {


### PR DESCRIPTION
This PR makes the project require Flutter 3.16 or newer.