### PR TITLE
Fix viewer double point bug

### DIFF
--- a/lib/pages/viewer/widget/double_point_listener.dart
+++ b/lib/pages/viewer/widget/double_point_listener.dart
@@ -31,9 +31,6 @@ class __DoublePointListener extends State<DoublePointListener> {
     return Listener(
       onPointerDown: (event) {
         _mpPoints++;
-        if (_mpPoints > 2) {
-          _mpPoints = 0;
-        }
         if (_mpPoints >= 2) {
           if (_onStateChanged) {
             _onStateChanged = false;
@@ -43,13 +40,15 @@ class __DoublePointListener extends State<DoublePointListener> {
       },
       onPointerUp: (event) {
         _mpPoints--;
-        if (_mpPoints < 0) {
-          _mpPoints = 0;
-        }
         if (_mpPoints < 1) {
           _onStateChanged = true;
           widget.onStateChanged(true);
         }
+      },
+      onPointerCancel: (event) {
+        _mpPoints = 0;
+        _onStateChanged = true;
+        widget.onStateChanged(true);
       },
       child: widget.child,
     );


### PR DESCRIPTION
Viewer의 고질적인 문제였던 멀티포인트 동작을 고칩니다.
이제 Vertical Viewer에서 InterativeZoom이 해제되지 않는 버그는 발생하지 않습니다.