### PR TITLE
Optimize ranked

### DIFF
--- a/violet-backend-core/Cargo.lock
+++ b/violet-backend-core/Cargo.lock
@@ -978,7 +978,6 @@ dependencies = [
 name = "ranked-server"
 version = "0.1.0"
 dependencies = [
- "rand",
  "redis",
  "rocket",
  "serde",

--- a/violet-backend-core/Cargo.lock
+++ b/violet-backend-core/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "rocket",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/violet-backend-core/Cargo.lock
+++ b/violet-backend-core/Cargo.lock
@@ -982,7 +982,6 @@ dependencies = [
  "rocket",
  "serde",
  "serde_json",
- "tempfile",
  "tokio",
 ]
 

--- a/violet-backend-core/Cargo.lock
+++ b/violet-backend-core/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
 name = "ranked-server"
 version = "0.1.0"
 dependencies = [
+ "rand",
  "redis",
  "rocket",
  "serde",

--- a/violet-backend-core/Cargo.toml
+++ b/violet-backend-core/Cargo.toml
@@ -9,4 +9,3 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 redis = "0.23"
-tempfile = "3.8"

--- a/violet-backend-core/Cargo.toml
+++ b/violet-backend-core/Cargo.toml
@@ -9,3 +9,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 redis = "0.23"
+rand = "0.8"

--- a/violet-backend-core/Cargo.toml
+++ b/violet-backend-core/Cargo.toml
@@ -10,4 +10,3 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 redis = "0.23"
 tempfile = "3.8"
-rand = "0.8"

--- a/violet-backend-core/Cargo.toml
+++ b/violet-backend-core/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 redis = "0.23"
 tempfile = "3.8"
+rand = "0.8"

--- a/violet-backend-core/Cargo.toml
+++ b/violet-backend-core/Cargo.toml
@@ -9,3 +9,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 redis = "0.23"
+tempfile = "3.8"

--- a/violet-backend-core/src/indexableset.rs
+++ b/violet-backend-core/src/indexableset.rs
@@ -1,0 +1,194 @@
+// 고성능 IndexableSet: BTreeSet의 캐시 친화적 레이아웃을 반영하여 성능 극대화
+use std::{cmp::Ordering, ops::Range};
+
+const MIN_DEGREE: usize = 4; // B-Tree 최소 차수
+
+#[derive(Debug, Clone)]
+struct Node<T: Clone> {
+    keys: Vec<T>,
+    children: Vec<Option<Box<Node<T>>>>,
+    size: usize,
+    leaf: bool,
+}
+
+impl<T: Ord + Clone> Node<T> {
+    fn new(leaf: bool) -> Self {
+        Node {
+            keys: Vec::new(),
+            children: Vec::new(),
+            size: 0,
+            leaf,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IndexableSet<T: Ord + Clone> {
+    root: Option<Box<Node<T>>>,
+}
+
+impl<T: Ord + Clone> IndexableSet<T> {
+    pub fn new() -> Self {
+        Self {
+            root: Some(Box::new(Node::new(true))),
+        }
+    }
+
+    pub fn insert(&mut self, val: T) {
+        let mut root = self.root.take().unwrap();
+        if root.keys.len() == 2 * MIN_DEGREE - 1 {
+            let mut s = Box::new(Node::new(false));
+            s.children.push(Some(root));
+            Self::split_child(&mut s, 0);
+            Self::insert_non_full(&mut s, val);
+            self.root = Some(s);
+        } else {
+            Self::insert_non_full(&mut root, val);
+            self.root = Some(root);
+        }
+    }
+
+    fn split_child(parent: &mut Box<Node<T>>, i: usize) {
+        let y = parent.children[i].take().unwrap();
+        let mut z = Box::new(Node::new(y.leaf));
+
+        z.keys.extend_from_slice(&y.keys[MIN_DEGREE..]);
+        let mid = y.keys[MIN_DEGREE - 1].clone();
+
+        if !y.leaf {
+            z.children.extend_from_slice(&y.children[MIN_DEGREE..]);
+        }
+
+        parent.keys.insert(i, mid);
+        parent.children.insert(i + 1, Some(z));
+
+        let mut y = *y;
+        y.keys.truncate(MIN_DEGREE - 1);
+        if !y.leaf {
+            y.children.truncate(MIN_DEGREE);
+        }
+
+        parent.children[i] = Some(Box::new(y));
+    }
+
+    fn insert_non_full(node: &mut Box<Node<T>>, val: T) {
+        let mut i = node.keys.len();
+
+        while i > 0 && val < node.keys[i - 1] {
+            i -= 1;
+        }
+
+        if node.leaf {
+            if node.keys.get(i).map_or(true, |k| k != &val) {
+                node.keys.insert(i, val);
+                node.size += 1;
+            }
+        } else {
+            if let Some(ref mut child) = node.children[i] {
+                if child.keys.len() == 2 * MIN_DEGREE - 1 {
+                    Self::split_child(node, i);
+                    if val > node.keys[i] {
+                        i += 1;
+                    }
+                }
+                Self::insert_non_full(node.children[i].as_mut().unwrap(), val);
+            }
+            node.size = node
+                .children
+                .iter()
+                .map(|c| c.as_ref().map_or(0, |n| n.size))
+                .sum::<usize>()
+                + node.keys.len();
+        }
+    }
+
+    pub fn get(&self, mut index: usize) -> Option<&T> {
+        let mut node = self.root.as_ref()?;
+        loop {
+            let mut total = 0;
+            for (i, key) in node.keys.iter().enumerate() {
+                let left_size = if node.leaf {
+                    i
+                } else {
+                    node.children[i].as_ref().map_or(0, |c| c.size)
+                };
+                if index < left_size {
+                    node = node.children[i].as_ref()?;
+                    break;
+                } else if index == left_size {
+                    return Some(key);
+                } else {
+                    index -= left_size + 1;
+                    total += left_size + 1;
+                }
+            }
+            if node.leaf {
+                return None;
+            }
+        }
+    }
+
+    pub fn range(&self, range: Range<usize>) -> Vec<&T> {
+        let mut res = Vec::with_capacity(range.end - range.start);
+        Self::range_inner(
+            self.root.as_ref().unwrap(),
+            range.start,
+            range.end,
+            0,
+            &mut res,
+        );
+        res
+    }
+
+    fn range_inner<'a>(
+        node: &'a Box<Node<T>>,
+        start: usize,
+        end: usize,
+        mut index: usize,
+        res: &mut Vec<&'a T>,
+    ) -> usize {
+        for i in 0..node.keys.len() {
+            if !node.leaf {
+                if let Some(ref child) = node.children[i] {
+                    index = Self::range_inner(child, start, end, index, res);
+                }
+            }
+            if index >= start && index < end {
+                res.push(&node.keys[i]);
+            }
+            index += 1;
+        }
+        if !node.leaf {
+            if let Some(ref child) = node.children.last().unwrap() {
+                index = Self::range_inner(child, start, end, index, res);
+            }
+        }
+        index
+    }
+
+    pub fn take(&mut self, val: &T) -> Option<T> {
+        Self::take_inner(&mut self.root, val)
+    }
+
+    fn take_inner(node: &mut Option<Box<Node<T>>>, val: &T) -> Option<T> {
+        let node_ref = node.as_mut()?;
+        match node_ref.keys.binary_search(val) {
+            Ok(i) => {
+                if node_ref.leaf {
+                    Some(node_ref.keys.remove(i))
+                } else {
+                    // Non-leaf node: more complex (not fully implemented here)
+                    // Could replace with predecessor/successor and recurse
+                    None
+                }
+            }
+            Err(i) => {
+                if node_ref.leaf {
+                    None
+                } else {
+                    Self::take_inner(&mut node_ref.children[i], val)
+                }
+            }
+        }
+    }
+}

--- a/violet-backend-core/src/indexableset.rs
+++ b/violet-backend-core/src/indexableset.rs
@@ -32,6 +32,7 @@ unsafe impl<T: Send + Ord + Clone + fmt::Debug> Send for IndexableSet<T> {}
 unsafe impl<T: Send + Ord + Clone + fmt::Debug> Sync for IndexableSet<T> {}
 
 impl<T: Ord + Clone + fmt::Debug> IndexableSet<T> {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             root: Some(Box::new(Node::new(true))),
@@ -108,13 +109,14 @@ impl<T: Ord + Clone + fmt::Debug> IndexableSet<T> {
         parent.children[i] = Some(y);
     }
 
+    #[allow(clippy::borrowed_box)]
     fn find_first_leaf(node: Option<&Box<Node<T>>>) -> Option<NonNull<Node<T>>> {
         let mut curr = node;
         while let Some(n) = curr {
             if n.leaf {
                 return Some(NonNull::from(&**n));
             }
-            curr = n.children.get(0)?.as_ref();
+            curr = n.children.first()?.as_ref();
         }
         None
     }

--- a/violet-backend-core/src/indexableset.rs
+++ b/violet-backend-core/src/indexableset.rs
@@ -1,7 +1,7 @@
 use core::fmt;
-use std::{cmp::Ordering, marker::PhantomData, ops::Range, ptr::NonNull};
+use std::{marker::PhantomData, ops::Range, ptr::NonNull};
 
-const MIN_DEGREE: usize = 4;
+const MIN_DEGREE: usize = 40;
 
 #[derive(Debug, Clone)]
 struct Node<T: Clone + fmt::Debug> {
@@ -63,16 +63,16 @@ impl<T: Ord + Clone + fmt::Debug> IndexableSet<T> {
                 Err(i) => node.keys.insert(i, val),
             }
         } else {
-            let i = match node.keys.binary_search(&val) {
+            let mut i = match node.keys.binary_search(&val) {
                 Ok(i) => i + 1,
                 Err(i) => i,
             };
+
             let child = node.children[i].as_mut().unwrap();
             if child.keys.len() == 2 * MIN_DEGREE - 1 {
                 self.split_child(node, i);
                 if val > node.keys[i] {
-                    self.insert_non_full(node.children[i + 1].as_mut().unwrap(), val);
-                    return;
+                    i += 1;
                 }
             }
             self.insert_non_full(node.children[i].as_mut().unwrap(), val);
@@ -82,26 +82,28 @@ impl<T: Ord + Clone + fmt::Debug> IndexableSet<T> {
     fn split_child(&mut self, parent: &mut Box<Node<T>>, i: usize) {
         let mut y = parent.children[i].take().unwrap();
         let mut z = Box::new(Node::new(y.leaf));
-
         let mid = MIN_DEGREE;
 
-        // B+Tree에서는 key는 leaf에도 남겨둠
-        z.keys.extend_from_slice(&y.keys[mid..]);
-        y.keys.truncate(mid);
+        // 키 분할
+        z.keys.extend(y.keys.drain(mid..));
 
         if y.leaf {
-            // z는 y 다음 leaf가 된다
+            // ✅ leaf chaining 유지
             z.next = y.next;
             let z_ptr = NonNull::from(&*z);
             y.next = Some(z_ptr);
+
+            // ✅ B+Tree에서는 leaf split 시 promote하지 않고 key만 복사
+            let separator = z.keys[0].clone();
+            parent.keys.insert(i, separator);
         } else {
-            // 내부 노드의 경우 children 도 잘라줘야 함
+            // ✅ internal node는 key를 하나 promote (중간 key)
+            let promoted = y.keys.pop().unwrap(); // mid번째 key
             z.children.extend(y.children.drain(mid..));
+
+            parent.keys.insert(i, promoted);
         }
 
-        // B+Tree에서는 오른쪽 child의 첫 키를 promote
-        let promoted = z.keys[0].clone();
-        parent.keys.insert(i, promoted);
         parent.children.insert(i + 1, Some(z));
         parent.children[i] = Some(y);
     }
@@ -288,20 +290,72 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_path_debug() {
+        let mut set = IndexableSet::new();
+
+        // 일부러 split 유도하는 값들 삽입
+        for &v in &[10, 20, 30, 40, 50, 60, 70, 49] {
+            println!("Inserting: {}", v);
+            print_leaf_chain_via_tree(&set.root);
+            set.insert(v);
+        }
+
+        // 트리 구조 출력
+        fn print_tree<T: std::fmt::Debug + Clone>(node: &Option<Box<Node<T>>>, depth: usize) {
+            if let Some(n) = node {
+                let indent = "  ".repeat(depth);
+                println!("{}Node (leaf={}): keys = {:?}", indent, n.leaf, n.keys);
+                if !n.leaf {
+                    for (i, c) in n.children.iter().enumerate() {
+                        println!("{}  child[{}]:", indent, i);
+                        print_tree(c, depth + 2);
+                    }
+                } else if let Some(next) = n.next {
+                    let next_node = unsafe { next.as_ref() };
+                    println!("{}  → next: keys = {:?}", indent, next_node.keys);
+                }
+            }
+        }
+
+        println!("===== Tree Structure =====");
+        print_tree(&set.root, 0);
+
+        // leaf chain도 직접 확인
+        println!("===== Leaf chain via next pointers =====");
+        let mut ptr = set.first_leaf;
+        while let Some(p) = ptr {
+            unsafe {
+                let node = p.as_ref();
+                println!("Leaf @{:p}: keys = {:?}", node as *const _, node.keys);
+                ptr = node.next;
+            }
+        }
+
+        // range_iter 결과 비교
+        let collected: Vec<_> = set.range_iter(0..8).copied().collect();
+        println!("Collected range_iter(0..8): {:?}", collected);
+    }
+
+    #[test]
     fn test_large_insert_and_range_iter_order() {
         use rand::{seq::SliceRandom, thread_rng};
         let mut set = IndexableSet::new();
-        let mut data: Vec<u32> = (0..1_00).collect();
+        let max = 10_000_000usize;
+        let mut data: Vec<usize> = (0..max).collect();
         data.shuffle(&mut thread_rng());
 
         for &val in &data {
-            println!("val: {}", val);
             set.insert(val);
         }
 
+        if max < 1000 {
+            println!("== Leaf chain traversal via tree ==");
+            print_leaf_chain_via_tree(&set.root);
+        }
+
         // 결과가 정렬되어 있어야 한다
-        let collected: Vec<_> = set.range_iter(0..1_00).copied().collect();
-        assert_eq!(collected, (0..1_00).collect::<Vec<_>>());
+        let collected: Vec<_> = set.range_iter(0..max).copied().collect();
+        assert_eq!(collected, (0..max).collect::<Vec<_>>());
     }
 
     #[test]
@@ -310,7 +364,7 @@ mod tests {
         set.insert(10);
         set.insert(10);
         let collected: Vec<_> = set.range_iter(0..2).copied().collect();
-        assert_eq!(collected, vec![10, 10]);
+        assert_eq!(collected, vec![10]);
     }
 
     #[test]

--- a/violet-backend-core/src/indexableset.rs
+++ b/violet-backend-core/src/indexableset.rs
@@ -1,36 +1,41 @@
-// 고성능 IndexableSet: BTreeSet의 캐시 친화적 레이아웃을 반영하여 성능 극대화
-use std::{cmp::Ordering, ops::Range};
+use core::fmt;
+use std::{cmp::Ordering, marker::PhantomData, ops::Range, ptr::NonNull};
 
-const MIN_DEGREE: usize = 4; // B-Tree 최소 차수
+const MIN_DEGREE: usize = 4;
 
 #[derive(Debug, Clone)]
-struct Node<T: Clone> {
-    keys: Vec<T>,
+struct Node<T: Clone + fmt::Debug> {
+    keys: Vec<T>, // In leaf: actual data, in internal: routing keys
     children: Vec<Option<Box<Node<T>>>>,
-    size: usize,
     leaf: bool,
+    next: Option<NonNull<Node<T>>>,
 }
 
-impl<T: Ord + Clone> Node<T> {
+impl<T: Clone + fmt::Debug> Node<T> {
     fn new(leaf: bool) -> Self {
-        Node {
+        Self {
             keys: Vec::new(),
             children: Vec::new(),
-            size: 0,
             leaf,
+            next: None,
         }
     }
 }
 
 #[derive(Debug)]
-pub struct IndexableSet<T: Ord + Clone> {
+pub struct IndexableSet<T: Ord + Clone + fmt::Debug> {
     root: Option<Box<Node<T>>>,
+    first_leaf: Option<NonNull<Node<T>>>,
 }
 
-impl<T: Ord + Clone> IndexableSet<T> {
+unsafe impl<T: Send + Ord + Clone + fmt::Debug> Send for IndexableSet<T> {}
+unsafe impl<T: Send + Ord + Clone + fmt::Debug> Sync for IndexableSet<T> {}
+
+impl<T: Ord + Clone + fmt::Debug> IndexableSet<T> {
     pub fn new() -> Self {
         Self {
             root: Some(Box::new(Node::new(true))),
+            first_leaf: None,
         }
     }
 
@@ -39,156 +44,299 @@ impl<T: Ord + Clone> IndexableSet<T> {
         if root.keys.len() == 2 * MIN_DEGREE - 1 {
             let mut s = Box::new(Node::new(false));
             s.children.push(Some(root));
-            Self::split_child(&mut s, 0);
-            Self::insert_non_full(&mut s, val);
+            self.split_child(&mut s, 0);
+            self.insert_non_full(&mut s, val);
             self.root = Some(s);
         } else {
-            Self::insert_non_full(&mut root, val);
+            self.insert_non_full(&mut root, val);
             self.root = Some(root);
         }
+        if self.first_leaf.is_none() {
+            self.first_leaf = Self::find_first_leaf(self.root.as_ref());
+        }
     }
 
-    fn split_child(parent: &mut Box<Node<T>>, i: usize) {
-        let y = parent.children[i].take().unwrap();
-        let mut z = Box::new(Node::new(y.leaf));
-
-        z.keys.extend_from_slice(&y.keys[MIN_DEGREE..]);
-        let mid = y.keys[MIN_DEGREE - 1].clone();
-
-        if !y.leaf {
-            z.children.extend_from_slice(&y.children[MIN_DEGREE..]);
-        }
-
-        parent.keys.insert(i, mid);
-        parent.children.insert(i + 1, Some(z));
-
-        let mut y = *y;
-        y.keys.truncate(MIN_DEGREE - 1);
-        if !y.leaf {
-            y.children.truncate(MIN_DEGREE);
-        }
-
-        parent.children[i] = Some(Box::new(y));
-    }
-
-    fn insert_non_full(node: &mut Box<Node<T>>, val: T) {
-        let mut i = node.keys.len();
-
-        while i > 0 && val < node.keys[i - 1] {
-            i -= 1;
-        }
-
+    fn insert_non_full(&mut self, node: &mut Box<Node<T>>, val: T) {
         if node.leaf {
-            if node.keys.get(i).map_or(true, |k| k != &val) {
-                node.keys.insert(i, val);
-                node.size += 1;
+            match node.keys.binary_search(&val) {
+                Ok(_) => {} // duplicate
+                Err(i) => node.keys.insert(i, val),
             }
         } else {
-            if let Some(ref mut child) = node.children[i] {
-                if child.keys.len() == 2 * MIN_DEGREE - 1 {
-                    Self::split_child(node, i);
-                    if val > node.keys[i] {
-                        i += 1;
+            let i = match node.keys.binary_search(&val) {
+                Ok(i) => i + 1,
+                Err(i) => i,
+            };
+            let child = node.children[i].as_mut().unwrap();
+            if child.keys.len() == 2 * MIN_DEGREE - 1 {
+                self.split_child(node, i);
+                if val > node.keys[i] {
+                    self.insert_non_full(node.children[i + 1].as_mut().unwrap(), val);
+                    return;
+                }
+            }
+            self.insert_non_full(node.children[i].as_mut().unwrap(), val);
+        }
+    }
+
+    fn split_child(&mut self, parent: &mut Box<Node<T>>, i: usize) {
+        let mut y = parent.children[i].take().unwrap();
+        let mut z = Box::new(Node::new(y.leaf));
+
+        let mid = MIN_DEGREE;
+
+        // B+Tree에서는 key는 leaf에도 남겨둠
+        z.keys.extend_from_slice(&y.keys[mid..]);
+        y.keys.truncate(mid);
+
+        if y.leaf {
+            // z는 y 다음 leaf가 된다
+            z.next = y.next;
+            let z_ptr = NonNull::from(&*z);
+            y.next = Some(z_ptr);
+        } else {
+            // 내부 노드의 경우 children 도 잘라줘야 함
+            z.children.extend(y.children.drain(mid..));
+        }
+
+        // B+Tree에서는 오른쪽 child의 첫 키를 promote
+        let promoted = z.keys[0].clone();
+        parent.keys.insert(i, promoted);
+        parent.children.insert(i + 1, Some(z));
+        parent.children[i] = Some(y);
+    }
+
+    fn find_first_leaf(node: Option<&Box<Node<T>>>) -> Option<NonNull<Node<T>>> {
+        let mut curr = node;
+        while let Some(n) = curr {
+            if n.leaf {
+                return Some(NonNull::from(&**n));
+            }
+            curr = n.children.get(0)?.as_ref();
+        }
+        None
+    }
+
+    pub fn range_iter(&self, range: Range<usize>) -> impl Iterator<Item = &T> {
+        struct LeafIter<'a, T: Clone + fmt::Debug> {
+            current: Option<NonNull<Node<T>>>,
+            global_index: usize,
+            range: Range<usize>,
+            index_in_node: usize,
+            _marker: PhantomData<&'a T>,
+        }
+
+        impl<'a, T: Clone + fmt::Debug> Iterator for LeafIter<'a, T> {
+            type Item = &'a T;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                while let Some(ptr) = self.current {
+                    let node = unsafe { ptr.as_ref() };
+                    while self.index_in_node < node.keys.len() {
+                        if self.range.contains(&self.global_index) {
+                            let result = &node.keys[self.index_in_node];
+                            self.index_in_node += 1;
+                            self.global_index += 1;
+                            return Some(result);
+                        }
+                        self.index_in_node += 1;
+                        self.global_index += 1;
                     }
+                    self.index_in_node = 0;
+                    self.current = node.next;
                 }
-                Self::insert_non_full(node.children[i].as_mut().unwrap(), val);
+                None
             }
-            node.size = node
-                .children
-                .iter()
-                .map(|c| c.as_ref().map_or(0, |n| n.size))
-                .sum::<usize>()
-                + node.keys.len();
         }
-    }
 
-    pub fn get(&self, mut index: usize) -> Option<&T> {
-        let mut node = self.root.as_ref()?;
-        loop {
-            let mut total = 0;
-            for (i, key) in node.keys.iter().enumerate() {
-                let left_size = if node.leaf {
-                    i
-                } else {
-                    node.children[i].as_ref().map_or(0, |c| c.size)
-                };
-                if index < left_size {
-                    node = node.children[i].as_ref()?;
-                    break;
-                } else if index == left_size {
-                    return Some(key);
-                } else {
-                    index -= left_size + 1;
-                    total += left_size + 1;
-                }
-            }
-            if node.leaf {
-                return None;
-            }
+        LeafIter {
+            current: self.first_leaf,
+            global_index: 0,
+            range,
+            index_in_node: 0,
+            _marker: PhantomData,
         }
-    }
-
-    pub fn range(&self, range: Range<usize>) -> Vec<&T> {
-        let mut res = Vec::with_capacity(range.end - range.start);
-        Self::range_inner(
-            self.root.as_ref().unwrap(),
-            range.start,
-            range.end,
-            0,
-            &mut res,
-        );
-        res
-    }
-
-    fn range_inner<'a>(
-        node: &'a Box<Node<T>>,
-        start: usize,
-        end: usize,
-        mut index: usize,
-        res: &mut Vec<&'a T>,
-    ) -> usize {
-        for i in 0..node.keys.len() {
-            if !node.leaf {
-                if let Some(ref child) = node.children[i] {
-                    index = Self::range_inner(child, start, end, index, res);
-                }
-            }
-            if index >= start && index < end {
-                res.push(&node.keys[i]);
-            }
-            index += 1;
-        }
-        if !node.leaf {
-            if let Some(ref child) = node.children.last().unwrap() {
-                index = Self::range_inner(child, start, end, index, res);
-            }
-        }
-        index
     }
 
     pub fn take(&mut self, val: &T) -> Option<T> {
-        Self::take_inner(&mut self.root, val)
+        Self::take_inner(self.root.as_mut(), val)
     }
 
-    fn take_inner(node: &mut Option<Box<Node<T>>>, val: &T) -> Option<T> {
-        let node_ref = node.as_mut()?;
-        match node_ref.keys.binary_search(val) {
-            Ok(i) => {
-                if node_ref.leaf {
-                    Some(node_ref.keys.remove(i))
-                } else {
-                    // Non-leaf node: more complex (not fully implemented here)
-                    // Could replace with predecessor/successor and recurse
-                    None
-                }
+    fn take_inner(node: Option<&mut Box<Node<T>>>, val: &T) -> Option<T> {
+        let node = node?;
+        if node.leaf {
+            if let Ok(i) = node.keys.binary_search(val) {
+                Some(node.keys.remove(i))
+            } else {
+                None
             }
-            Err(i) => {
-                if node_ref.leaf {
-                    None
+        } else {
+            let i = match node.keys.binary_search(val) {
+                Ok(i) => i + 1,
+                Err(i) => i,
+            };
+            Self::take_inner(node.children[i].as_mut(), val)
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_child_leaf_correctness() {
+        let mut set = IndexableSet::new();
+
+        // leaf 하나에 가득 차도록 삽입 (2 * MIN_DEGREE)
+        for i in 0..(2 * MIN_DEGREE) {
+            set.insert(i as i32);
+        }
+
+        // 강제로 split 발생하도록 루트부터 다시 삽입
+        set.insert((2 * MIN_DEGREE) as i32);
+
+        let root = set.root.as_ref().unwrap();
+
+        // 1. 루트는 내부 노드여야 함
+        assert!(!root.leaf);
+
+        // 2. 자식은 2개 있어야 하고, 모두 leaf
+        assert_eq!(root.children.len(), 2);
+        let left = root.children[0].as_ref().unwrap();
+        let right = root.children[1].as_ref().unwrap();
+        assert!(left.leaf && right.leaf);
+
+        // 3. key가 잘 분할되어 있음
+        assert_eq!(left.keys.len(), MIN_DEGREE); // 0..MIN_DEGREE
+        assert_eq!(right.keys.len(), MIN_DEGREE + 1); // MIN_DEGREE..(2*MIN_DEGREE)
+
+        // 4. 루트의 keys에는 오른쪽 leaf의 첫 키가 올라와 있어야 함 (B+Tree promote rule)
+        assert_eq!(root.keys.len(), 1);
+        assert_eq!(root.keys[0], right.keys[0]);
+
+        // 5. leaf chaining 확인 (left.next -> right)
+        let right_ptr = NonNull::from(&**right);
+        assert_eq!(left.next, Some(right_ptr));
+    }
+
+    #[test]
+    fn test_insert_and_range_iter_order() {
+        let mut set = IndexableSet::new();
+        for &val in &[10, 20, 5, 15, 25] {
+            set.insert(val);
+        }
+
+        let collected: Vec<_> = set.range_iter(0..5).copied().collect();
+        assert_eq!(collected, vec![5, 10, 15, 20, 25]);
+    }
+
+    fn print_leaf_chain_via_tree<T: std::fmt::Debug + Clone>(node: &Option<Box<Node<T>>>) {
+        if let Some(n) = node {
+            let this_ptr = n.as_ref() as *const Node<T>;
+            println!("Leaf {} {:p} keys: {:?}", n.leaf, this_ptr, n.keys);
+            if n.leaf {
+                if let Some(next) = n.next {
+                    let next_node = unsafe { next.as_ref() };
+                    println!(
+                        "   → next {:p} keys: {:?}",
+                        next_node as *const Node<T>, next_node.keys
+                    );
                 } else {
-                    Self::take_inner(&mut node_ref.children[i], val)
+                    println!("   → next: None");
+                }
+            } else {
+                // 내부 노드: 자식들을 재귀적으로 검사
+                for child in &n.children {
+                    print_leaf_chain_via_tree(child);
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_range_iter_correctness_small() {
+        let mut set = IndexableSet::new();
+        let max = 40;
+        for i in 0..max {
+            set.insert(i);
+        }
+
+        println!("== Leaf chain traversal via tree ==");
+        print_leaf_chain_via_tree(&set.root);
+
+        // 1. leaf chaining 검증
+        let mut visited = vec![];
+        let mut ptr = set.first_leaf;
+        while let Some(p) = ptr {
+            unsafe {
+                let node = p.as_ref();
+                visited.extend_from_slice(&node.keys);
+                println!("node: {:?}", node.keys);
+                println!("next: {:?}", node.next);
+                ptr = node.next;
+            }
+        }
+
+        // leaf chaining으로 순회한 결과도 정렬된 전체 key와 일치해야 함
+        assert_eq!(visited, (0..max).collect::<Vec<_>>());
+
+        // 2. range_iter로 정렬 순서 확인
+        let collected: Vec<_> = set.range_iter(0..max).copied().collect();
+        let expected: Vec<_> = (0..max).collect();
+
+        assert_eq!(collected, expected);
+    }
+
+    #[test]
+    fn test_large_insert_and_range_iter_order() {
+        use rand::{seq::SliceRandom, thread_rng};
+        let mut set = IndexableSet::new();
+        let mut data: Vec<u32> = (0..1_00).collect();
+        data.shuffle(&mut thread_rng());
+
+        for &val in &data {
+            println!("val: {}", val);
+            set.insert(val);
+        }
+
+        // 결과가 정렬되어 있어야 한다
+        let collected: Vec<_> = set.range_iter(0..1_00).copied().collect();
+        assert_eq!(collected, (0..1_00).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_duplicate_insert() {
+        let mut set = IndexableSet::new();
+        set.insert(10);
+        set.insert(10);
+        let collected: Vec<_> = set.range_iter(0..2).copied().collect();
+        assert_eq!(collected, vec![10, 10]);
+    }
+
+    #[test]
+    fn test_take_existing() {
+        let mut set = IndexableSet::new();
+        for &val in &[1, 2, 3, 4] {
+            set.insert(val);
+        }
+        assert_eq!(set.take(&3), Some(3));
+        let collected: Vec<_> = set.range_iter(0..3).copied().collect();
+        assert_eq!(collected, vec![1, 2, 4]);
+    }
+
+    #[test]
+    fn test_take_nonexistent() {
+        let mut set = IndexableSet::new();
+        set.insert(42);
+        assert_eq!(set.take(&100), None);
+        let collected: Vec<_> = set.range_iter(0..1).copied().collect();
+        assert_eq!(collected, vec![42]);
+    }
+
+    #[test]
+    fn test_empty_range_iter() {
+        let set: IndexableSet<i32> = IndexableSet::new();
+        let collected: Vec<i32> = set.range_iter(0..10).copied().collect();
+        assert_eq!(collected, vec![0; 0]);
     }
 }

--- a/violet-backend-core/src/main.rs
+++ b/violet-backend-core/src/main.rs
@@ -52,8 +52,10 @@ async fn flushall(state: &State<RankedState>) -> String {
 
 #[launch]
 fn rocket() -> _ {
-    rocket::build().manage(RankedState::new()).mount(
-        "/",
-        routes![zadd, zincrby, zincrbyp, zrange, zrevrange, flushall],
-    )
+    rocket::build()
+        .manage(RankedState::new("pages".to_string()))
+        .mount(
+            "/",
+            routes![zadd, zincrby, zincrbyp, zrange, zrevrange, flushall],
+        )
 }

--- a/violet-backend-core/src/main.rs
+++ b/violet-backend-core/src/main.rs
@@ -52,10 +52,8 @@ async fn flushall(state: &State<RankedState>) -> String {
 
 #[launch]
 fn rocket() -> _ {
-    rocket::build()
-        .manage(RankedState::new("pages".to_string()))
-        .mount(
-            "/",
-            routes![zadd, zincrby, zincrbyp, zrange, zrevrange, flushall],
-        )
+    rocket::build().manage(RankedState::new()).mount(
+        "/",
+        routes![zadd, zincrby, zincrbyp, zrange, zrevrange, flushall],
+    )
 }

--- a/violet-backend-core/src/main.rs
+++ b/violet-backend-core/src/main.rs
@@ -3,6 +3,7 @@ use rocket::State;
 
 use memory::{RankedState, ZAddRequest, ZIncrByPeriodRequest, ZIncrByRequest, ZRangeRequest};
 
+mod indexableset;
 mod memory;
 
 #[macro_use]

--- a/violet-backend-core/src/main.rs
+++ b/violet-backend-core/src/main.rs
@@ -3,7 +3,7 @@ use rocket::State;
 
 use memory::{RankedState, ZAddRequest, ZIncrByPeriodRequest, ZIncrByRequest, ZRangeRequest};
 
-mod indexableset;
+pub mod indexableset;
 mod memory;
 
 #[macro_use]

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -306,6 +306,8 @@ impl RankedState {
 mod tests {
     use std::{sync::Arc, thread, time::Duration};
 
+    use rand::Rng;
+
     use super::*;
 
     #[test]
@@ -744,18 +746,22 @@ mod tests {
             num_entries as f64 / insert_duration.as_secs_f64()
         );
 
-        // zrevrange 성능 테스트
-        let range_request = ZRangeRequest {
-            offset: 0,
-            count: 100,
-            withscores: true,
-        };
+        // 쿼리 테스트 - 랜덤 액세스
+        let mut rng = rand::thread_rng();
+        let mut total_query_duration = Duration::new(0, 0);
 
         // 100번 반복 테스트
-        let mut total_query_duration = Duration::new(0, 0);
-        for _ in 0..100 {
-            let query_start = Instant::now();
-            let _result = state.zrevrange("test".to_string(), range_request.clone());
+        for _ in 0..10 {
+            // 0부터 5000만까지 랜덤 오프셋 생성
+            let random_offset = rng.gen_range(0..50_000_000);
+            let range_request = ZRangeRequest {
+                offset: random_offset,
+                count: 100,
+                withscores: true,
+            };
+
+            let query_start = std::time::Instant::now();
+            let _result = state.zrevrange("test".to_string(), range_request);
             total_query_duration += query_start.elapsed();
         }
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -705,7 +705,7 @@ mod tests {
         use std::time::Instant;
 
         let state = Arc::new(RankedState::new());
-        let num_entries = 50_000_0;
+        let num_entries = 50_000_00;
         let num_threads = 8;
         let entries_per_thread = num_entries / num_threads;
 
@@ -755,16 +755,16 @@ mod tests {
         // 100번 반복 테스트
         for _ in 0..10 {
             // 0부터 5000만까지 랜덤 오프셋 생성
-            let random_offset = rng.gen_range(0..50_000_0);
+            let random_offset = rng.gen_range(0..num_entries);
             let range_request = ZRangeRequest {
-                offset: 0,
+                offset: random_offset,
                 count: 100,
                 withscores: true,
             };
 
             let query_start = std::time::Instant::now();
             let _result = state.zrevrange("test".to_string(), range_request);
-            println!("{}", _result);
+            // println!("{}", _result);
             total_query_duration += query_start.elapsed();
         }
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -523,63 +523,92 @@ impl RankedState {
         let mut remaining = request.count;
         let mut offset = request.offset;
 
-        // 현재 메모리에 있는 데이터 처리
+        // 1. 메모리에 있는 데이터 처리
         {
             let tables = self.tables.read().unwrap();
             if let Some(sorted_entries) = tables.get(&table) {
-                let start = offset.min(sorted_entries.len());
-                let end = (start + remaining).min(sorted_entries.len());
+                // 메모리에 있는 데이터의 범위 확인
+                let memory_min = sorted_entries.first().map(|e| e.value).unwrap_or(i64::MAX);
+                let memory_max = sorted_entries.last().map(|e| e.value).unwrap_or(i64::MIN);
 
-                result = sorted_entries
-                    .iter()
-                    .rev()
-                    .skip(start)
-                    .take(end - start)
-                    .map(|entry| {
-                        if request.withscores {
-                            format!("{}:{}", entry.member, entry.value)
-                        } else {
-                            entry.member.to_string()
-                        }
-                    })
-                    .collect();
+                // 현재 페이지 번호 확인
+                let current_page = self.current_page.read().unwrap();
+                let page_num = *current_page.get(&table).unwrap_or(&0);
 
-                remaining -= end - start;
-                offset = offset.saturating_sub(sorted_entries.len());
+                // 디스크의 페이지들을 확인하여 정렬 순서 결정
+                let mut disk_pages = Vec::new();
+                for i in 0..page_num {
+                    if let Ok(page) =
+                        Page::load_from_file(Path::new(&self.get_page_path(&table, i)))
+                    {
+                        disk_pages.push((i, page.min_value, page.max_value));
+                    }
+                }
+
+                // 메모리 데이터가 처리될 위치 계산 (역순)
+                let mut memory_start = 0;
+                let mut memory_end = sorted_entries.len();
+
+                // 디스크 페이지 중 메모리 데이터보다 큰 값이 있는지 확인
+                for (_, min, max) in disk_pages.iter().rev() {
+                    if *min > memory_max {
+                        memory_start += PAGE_SIZE;
+                        memory_end += PAGE_SIZE;
+                    } else if *max < memory_min {
+                        break;
+                    }
+                }
+
+                // 메모리 데이터 처리 (역순)
+                let start = offset.saturating_sub(memory_start);
+                let end = (start + remaining).min(memory_end - memory_start);
+
+                if start < sorted_entries.len() {
+                    result = sorted_entries
+                        .iter()
+                        .rev()
+                        .skip(start)
+                        .take(end - start)
+                        .map(|entry| {
+                            if request.withscores {
+                                format!("{}:{}", entry.member, entry.value)
+                            } else {
+                                entry.member.to_string()
+                            }
+                        })
+                        .collect();
+
+                    remaining -= end - start;
+                    offset = offset.saturating_sub(memory_end);
+                }
             }
         }
 
-        // 디스크의 페이지 처리
+        // 2. 디스크의 페이지 처리 (역순)
         if remaining > 0 {
             let current_page = self.current_page.read().unwrap();
             let mut page_num = *current_page.get(&table).unwrap_or(&0);
 
             while remaining > 0 && page_num > 0 {
                 page_num -= 1;
-                if let Ok(_) = self.load_page(&table, page_num) {
-                    let tables = self.tables.read().unwrap();
-                    if let Some(sorted_entries) = tables.get(&table) {
-                        let start = offset.min(sorted_entries.len());
-                        let end = (start + remaining).min(sorted_entries.len());
+                if let Ok(page) =
+                    Page::load_from_file(Path::new(&self.get_page_path(&table, page_num)))
+                {
+                    let start = offset.min(page.entries.len());
+                    let end = (start + remaining).min(page.entries.len());
 
-                        result.extend(
-                            sorted_entries
-                                .iter()
-                                .rev()
-                                .skip(start)
-                                .take(end - start)
-                                .map(|entry| {
-                                    if request.withscores {
-                                        format!("{}:{}", entry.member, entry.value)
-                                    } else {
-                                        entry.member.to_string()
-                                    }
-                                }),
-                        );
+                    result.extend(page.entries.iter().rev().skip(start).take(end - start).map(
+                        |entry| {
+                            if request.withscores {
+                                format!("{}:{}", entry.member, entry.value)
+                            } else {
+                                entry.member.to_string()
+                            }
+                        },
+                    ));
 
-                        remaining -= end - start;
-                        offset = offset.saturating_sub(sorted_entries.len());
-                    }
+                    remaining -= end - start;
+                    offset = offset.saturating_sub(page.entries.len());
                 }
             }
         }

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const PAGE_SIZE: usize = 5_000_00000;
-const MAX_MEMORY_ENTRIES: usize = 2_000_00000; // 약 2GB 제한
+const PAGE_SIZE: usize = 5_000_000;
+const MAX_MEMORY_ENTRIES: usize = 5_000_000; // 약 2GB 제한
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -467,12 +467,14 @@ impl RankedState {
         {
             let tables = self.tables.read().unwrap();
             if let Some(sorted_entries) = tables.get(&table) {
-                let entries: Vec<_> = sorted_entries.iter().rev().collect();
-                let start = offset.min(entries.len());
-                let end = (start + remaining).min(entries.len());
+                let start = offset.min(sorted_entries.len());
+                let end = (start + remaining).min(sorted_entries.len());
 
-                result = entries[start..end]
+                result = sorted_entries
                     .iter()
+                    .rev()
+                    .skip(start)
+                    .take(end - start)
                     .map(|entry| {
                         if request.withscores {
                             format!("{}:{}", entry.member, entry.value)
@@ -482,16 +484,8 @@ impl RankedState {
                     })
                     .collect();
 
-                // for entry in &entries[start..end] {
-                //     if request.withscores {
-                //         result.push(format!("{}:{}", entry.member, entry.value));
-                //     } else {
-                //         result.push(entry.member.to_string());
-                //     }
-                // }
-
                 remaining -= end - start;
-                offset = offset.saturating_sub(entries.len());
+                offset = offset.saturating_sub(sorted_entries.len());
             }
         }
 
@@ -505,20 +499,26 @@ impl RankedState {
                 if let Ok(_) = self.load_page(&table, page_num) {
                     let tables = self.tables.read().unwrap();
                     if let Some(sorted_entries) = tables.get(&table) {
-                        let entries: Vec<_> = sorted_entries.iter().rev().collect();
-                        let start = offset.min(entries.len());
-                        let end = (start + remaining).min(entries.len());
+                        let start = offset.min(sorted_entries.len());
+                        let end = (start + remaining).min(sorted_entries.len());
 
-                        for entry in &entries[start..end] {
-                            if request.withscores {
-                                result.push(format!("{}:{}", entry.member, entry.value));
-                            } else {
-                                result.push(entry.member.to_string());
-                            }
-                        }
+                        result.extend(
+                            sorted_entries
+                                .iter()
+                                .rev()
+                                .skip(start)
+                                .take(end - start)
+                                .map(|entry| {
+                                    if request.withscores {
+                                        format!("{}:{}", entry.member, entry.value)
+                                    } else {
+                                        entry.member.to_string()
+                                    }
+                                }),
+                        );
 
                         remaining -= end - start;
-                        offset = offset.saturating_sub(entries.len());
+                        offset = offset.saturating_sub(sorted_entries.len());
                     }
                 }
             }
@@ -556,6 +556,8 @@ impl RankedState {
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, thread, time::Duration};
+
+    use rand::Rng;
 
     use super::*;
 
@@ -952,7 +954,7 @@ mod tests {
     #[test]
     fn test_page_stress() {
         let state = Arc::new(RankedState::new("./page".to_string()));
-        let num_entries = 50_000_0;
+        let num_entries = 50_000_00;
         let num_threads = 8;
         let entries_per_thread = num_entries / num_threads;
 
@@ -995,18 +997,22 @@ mod tests {
         let page_count = current_page.get("test").unwrap_or(&0);
         println!("Total pages created: {}", page_count);
 
-        // 쿼리 테스트
-        let range_request = ZRangeRequest {
-            offset: 0,
-            count: 100,
-            withscores: true,
-        };
+        // 쿼리 테스트 - 랜덤 액세스
+        let mut rng = rand::thread_rng();
+        let mut total_query_duration = Duration::new(0, 0);
 
         // 100번 반복 테스트
-        let mut total_query_duration = Duration::new(0, 0);
-        for _ in 0..100 {
+        for _ in 0..10 {
+            // 0부터 5000만까지 랜덤 오프셋 생성
+            let random_offset = rng.gen_range(0..50_000_00);
+            let range_request = ZRangeRequest {
+                offset: random_offset,
+                count: 100,
+                withscores: true,
+            };
+
             let query_start = std::time::Instant::now();
-            let _result = state.zrevrange("test".to_string(), range_request.clone());
+            let _result = state.zrevrange("test".to_string(), range_request);
             total_query_duration += query_start.elapsed();
         }
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -248,8 +248,7 @@ impl RankedState {
         let tables = self.tables.read().unwrap();
         if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
-                .range(request.offset..request.offset + request.count)
-                .into_iter()
+                .range_iter(request.offset..request.offset + request.count)
                 .map(|entry| {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)
@@ -270,9 +269,8 @@ impl RankedState {
         let tables = self.tables.read().unwrap();
         if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
-                .range(request.offset..request.offset + request.count)
-                .into_iter()
-                .rev() // TODO: 수정
+                .range_iter(request.offset..request.offset + request.count)
+                // .rev() // TODO: 수정
                 .map(|entry| {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)
@@ -707,7 +705,7 @@ mod tests {
         use std::time::Instant;
 
         let state = Arc::new(RankedState::new());
-        let num_entries = 50_000_00;
+        let num_entries = 50_000_0;
         let num_threads = 8;
         let entries_per_thread = num_entries / num_threads;
 
@@ -746,6 +744,10 @@ mod tests {
             num_entries as f64 / insert_duration.as_secs_f64()
         );
 
+        // let tables = state.tables.read().unwrap();
+        // let sorted_entries = tables.get("test").unwrap();
+        // println!("Total entries in memory: {}", sorted_entries.keys.len());
+
         // 쿼리 테스트 - 랜덤 액세스
         let mut rng = rand::thread_rng();
         let mut total_query_duration = Duration::new(0, 0);
@@ -753,15 +755,16 @@ mod tests {
         // 100번 반복 테스트
         for _ in 0..10 {
             // 0부터 5000만까지 랜덤 오프셋 생성
-            let random_offset = rng.gen_range(0..50_000_00);
+            let random_offset = rng.gen_range(0..50_000_0);
             let range_request = ZRangeRequest {
-                offset: random_offset,
+                offset: 0,
                 count: 100,
                 withscores: true,
             };
 
             let query_start = std::time::Instant::now();
             let _result = state.zrevrange("test".to_string(), range_request);
+            println!("{}", _result);
             total_query_duration += query_start.elapsed();
         }
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const PAGE_SIZE: usize = 5_000_000;
-const MAX_MEMORY_ENTRIES: usize = 5_000_000; // 약 2GB 제한
+const PAGE_SIZE: usize = 5_000_00000;
+const MAX_MEMORY_ENTRIES: usize = 2_000_00000; // 약 2GB 제한
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -467,14 +467,12 @@ impl RankedState {
         {
             let tables = self.tables.read().unwrap();
             if let Some(sorted_entries) = tables.get(&table) {
-                let start = offset.min(sorted_entries.len());
-                let end = (start + remaining).min(sorted_entries.len());
+                let entries: Vec<_> = sorted_entries.iter().rev().collect();
+                let start = offset.min(entries.len());
+                let end = (start + remaining).min(entries.len());
 
-                result = sorted_entries
+                result = entries[start..end]
                     .iter()
-                    .rev()
-                    .skip(start)
-                    .take(end - start)
                     .map(|entry| {
                         if request.withscores {
                             format!("{}:{}", entry.member, entry.value)
@@ -484,8 +482,16 @@ impl RankedState {
                     })
                     .collect();
 
+                // for entry in &entries[start..end] {
+                //     if request.withscores {
+                //         result.push(format!("{}:{}", entry.member, entry.value));
+                //     } else {
+                //         result.push(entry.member.to_string());
+                //     }
+                // }
+
                 remaining -= end - start;
-                offset = offset.saturating_sub(sorted_entries.len());
+                offset = offset.saturating_sub(entries.len());
             }
         }
 
@@ -499,26 +505,20 @@ impl RankedState {
                 if let Ok(_) = self.load_page(&table, page_num) {
                     let tables = self.tables.read().unwrap();
                     if let Some(sorted_entries) = tables.get(&table) {
-                        let start = offset.min(sorted_entries.len());
-                        let end = (start + remaining).min(sorted_entries.len());
+                        let entries: Vec<_> = sorted_entries.iter().rev().collect();
+                        let start = offset.min(entries.len());
+                        let end = (start + remaining).min(entries.len());
 
-                        result.extend(
-                            sorted_entries
-                                .iter()
-                                .rev()
-                                .skip(start)
-                                .take(end - start)
-                                .map(|entry| {
-                                    if request.withscores {
-                                        format!("{}:{}", entry.member, entry.value)
-                                    } else {
-                                        entry.member.to_string()
-                                    }
-                                }),
-                        );
+                        for entry in &entries[start..end] {
+                            if request.withscores {
+                                result.push(format!("{}:{}", entry.member, entry.value));
+                            } else {
+                                result.push(entry.member.to_string());
+                            }
+                        }
 
                         remaining -= end - start;
-                        offset = offset.saturating_sub(sorted_entries.len());
+                        offset = offset.saturating_sub(entries.len());
                     }
                 }
             }
@@ -556,8 +556,6 @@ impl RankedState {
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, thread, time::Duration};
-
-    use rand::Rng;
 
     use super::*;
 
@@ -954,7 +952,7 @@ mod tests {
     #[test]
     fn test_page_stress() {
         let state = Arc::new(RankedState::new("./page".to_string()));
-        let num_entries = 50_000_00;
+        let num_entries = 50_000_0;
         let num_threads = 8;
         let entries_per_thread = num_entries / num_threads;
 
@@ -997,22 +995,18 @@ mod tests {
         let page_count = current_page.get("test").unwrap_or(&0);
         println!("Total pages created: {}", page_count);
 
-        // 쿼리 테스트 - 랜덤 액세스
-        let mut rng = rand::thread_rng();
-        let mut total_query_duration = Duration::new(0, 0);
+        // 쿼리 테스트
+        let range_request = ZRangeRequest {
+            offset: 0,
+            count: 100,
+            withscores: true,
+        };
 
         // 100번 반복 테스트
-        for _ in 0..10 {
-            // 0부터 5000만까지 랜덤 오프셋 생성
-            let random_offset = rng.gen_range(0..50_000_00);
-            let range_request = ZRangeRequest {
-                offset: random_offset,
-                count: 100,
-                withscores: true,
-            };
-
+        let mut total_query_duration = Duration::new(0, 0);
+        for _ in 0..100 {
             let query_start = std::time::Instant::now();
-            let _result = state.zrevrange("test".to_string(), range_request);
+            let _result = state.zrevrange("test".to_string(), range_request.clone());
             total_query_duration += query_start.elapsed();
         }
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, BinaryHeap, HashMap};
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,14 +84,14 @@ pub struct ZRangeRequest {
 
 #[allow(clippy::type_complexity)]
 pub struct RankedState {
-    tables: Mutex<HashMap<String, (HashMap<String, RankedEntry>, BTreeSet<RankedEntry>)>>,
+    tables: RwLock<HashMap<String, (HashMap<String, RankedEntry>, BTreeSet<RankedEntry>)>>,
     expire_queue: Mutex<BinaryHeap<ExpireEntry>>,
 }
 
 impl RankedState {
     pub fn new() -> Self {
         RankedState {
-            tables: Mutex::new(HashMap::new()),
+            tables: RwLock::new(HashMap::new()),
             expire_queue: Mutex::new(BinaryHeap::new()),
         }
     }
@@ -102,7 +102,7 @@ impl RankedState {
             .unwrap()
             .as_secs();
 
-        let mut tables = self.tables.lock().unwrap();
+        let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
 
         while let Some(entry) = expire_queue.peek() {
@@ -135,7 +135,7 @@ impl RankedState {
     pub fn zadd(&self, table: String, request: ZAddRequest) -> String {
         self.process_expired_entries();
 
-        let mut tables = self.tables.lock().unwrap();
+        let mut tables = self.tables.write().unwrap();
         let (entries, sorted_entries) = tables
             .entry(table)
             .or_insert_with(|| (HashMap::new(), BTreeSet::new()));
@@ -161,7 +161,7 @@ impl RankedState {
     pub fn zincrby(&self, table: String, request: ZIncrByRequest) -> String {
         self.process_expired_entries();
 
-        let mut tables = self.tables.lock().unwrap();
+        let mut tables = self.tables.write().unwrap();
         let (entries, sorted_entries) = tables
             .entry(table)
             .or_insert_with(|| (HashMap::new(), BTreeSet::new()));
@@ -190,7 +190,7 @@ impl RankedState {
             .unwrap()
             .as_secs();
 
-        let mut tables = self.tables.lock().unwrap();
+        let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
         let (entries, sorted_entries) = tables
             .entry(table.clone())
@@ -226,7 +226,7 @@ impl RankedState {
     pub fn zrange(&self, table: String, request: ZRangeRequest) -> String {
         self.process_expired_entries();
 
-        let tables = self.tables.lock().unwrap();
+        let tables = self.tables.read().unwrap();
         if let Some((_, sorted_entries)) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
                 .iter()
@@ -250,7 +250,7 @@ impl RankedState {
     pub fn zrevrange(&self, table: String, request: ZRangeRequest) -> String {
         self.process_expired_entries();
 
-        let tables = self.tables.lock().unwrap();
+        let tables = self.tables.read().unwrap();
         if let Some((_, sorted_entries)) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
                 .iter()
@@ -273,7 +273,7 @@ impl RankedState {
     }
 
     pub fn flushall(&self) -> String {
-        let mut tables = self.tables.lock().unwrap();
+        let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
         tables.clear();
         expire_queue.clear();
@@ -749,7 +749,7 @@ mod tests {
         );
 
         // 메모리 사용량 확인
-        let tables = state.tables.lock().unwrap();
+        let tables = state.tables.read().unwrap();
         let (entries, _) = tables.get("test").unwrap();
         println!("Total entries in memory: {}", entries.len());
         println!(

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::indexableset::IndexableSet;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -83,7 +85,7 @@ pub struct ZRangeRequest {
 
 #[allow(clippy::type_complexity)]
 pub struct RankedState {
-    tables: RwLock<HashMap<String, BTreeSet<RankedEntry>>>,
+    tables: RwLock<HashMap<String, IndexableSet<RankedEntry>>>,
     expire_queue: Mutex<BinaryHeap<ExpireEntry>>,
     table_lookup: RwLock<Vec<String>>,
     table_indices: RwLock<HashMap<String, usize>>,
@@ -161,7 +163,7 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(IndexableSet::new);
 
         let entry = RankedEntry {
             value: request.value,
@@ -169,7 +171,7 @@ impl RankedState {
             expire: None,
         };
 
-        sorted_entries.replace(entry);
+        sorted_entries.insert(entry);
 
         "OK".to_string()
     }
@@ -179,7 +181,7 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(IndexableSet::new);
 
         let mut entry = sorted_entries
             .take(&RankedEntry {
@@ -212,7 +214,7 @@ impl RankedState {
 
         let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(IndexableSet::new);
 
         let mut entry = sorted_entries
             .take(&RankedEntry {
@@ -246,9 +248,8 @@ impl RankedState {
         let tables = self.tables.read().unwrap();
         if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
-                .iter()
-                .skip(request.offset)
-                .take(request.count)
+                .range(request.offset..request.offset + request.count)
+                .into_iter()
                 .map(|entry| {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)
@@ -269,10 +270,9 @@ impl RankedState {
         let tables = self.tables.read().unwrap();
         if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
-                .iter()
-                .rev()
-                .skip(request.offset)
-                .take(request.count)
+                .range(request.offset..request.offset + request.count)
+                .into_iter()
+                .rev() // TODO: 수정
                 .map(|entry| {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)
@@ -707,7 +707,7 @@ mod tests {
         use std::time::Instant;
 
         let state = Arc::new(RankedState::new());
-        let num_entries = 50_000_000;
+        let num_entries = 50_000_00;
         let num_threads = 8;
         let entries_per_thread = num_entries / num_threads;
 
@@ -753,7 +753,7 @@ mod tests {
         // 100번 반복 테스트
         for _ in 0..10 {
             // 0부터 5000만까지 랜덤 오프셋 생성
-            let random_offset = rng.gen_range(0..50_000_000);
+            let random_offset = rng.gen_range(0..50_000_00);
             let range_request = ZRangeRequest {
                 offset: random_offset,
                 count: 100,
@@ -778,7 +778,7 @@ mod tests {
         // 메모리 사용량 확인
         let tables = state.tables.read().unwrap();
         let sorted_entries = tables.get("test").unwrap();
-        println!("Total entries in memory: {}", sorted_entries.len());
+        // println!("Total entries in memory: {}", sorted_entries.len());
 
         let size_of_ranked_entry = std::mem::size_of::<RankedEntry>();
         let size_of_expire_entry = std::mem::size_of::<ExpireEntry>();
@@ -807,10 +807,10 @@ mod tests {
             "Memory optimization: Saving ~{} bytes per entry",
             original_exp_entry_size - size_of_expire_entry
         );
-        println!(
-            "Total memory saved: ~{} MB",
-            (original_exp_entry_size - size_of_expire_entry) * sorted_entries.len() / (1024 * 1024)
-        );
+        // println!(
+        //     "Total memory saved: ~{} MB",
+        //     (original_exp_entry_size - size_of_expire_entry) * sorted_entries.len() / (1024 * 1024)
+        // );
 
         // 만료 큐 크기 확인
         let expire_queue = state.expire_queue.lock().unwrap();

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, BinaryHeap, HashMap};
+use std::fs;
+use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const PAGE_SIZE: usize = 5_000_00000;
+const MAX_MEMORY_ENTRIES: usize = 2_000_00000; // 약 2GB 제한
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -32,6 +37,41 @@ impl Ord for RankedEntry {
             Ordering::Equal => self.member.cmp(&other.member),
             ordering => ordering,
         }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Page {
+    entries: Vec<RankedEntry>,
+    min_value: i64,
+    max_value: i64,
+}
+
+impl Page {
+    fn new() -> Self {
+        Page {
+            entries: Vec::with_capacity(PAGE_SIZE),
+            min_value: i64::MAX,
+            max_value: i64::MIN,
+        }
+    }
+
+    fn add_entry(&mut self, entry: RankedEntry) {
+        self.min_value = self.min_value.min(entry.value);
+        self.max_value = self.max_value.max(entry.value);
+        self.entries.push(entry);
+    }
+
+    fn save_to_file(&self, path: &Path) -> std::io::Result<()> {
+        let json = serde_json::to_string(self)?;
+        fs::write(path, json)?;
+        Ok(())
+    }
+
+    fn load_from_file(path: &Path) -> std::io::Result<Self> {
+        let json = fs::read_to_string(path)?;
+        let page: Page = serde_json::from_str(&json)?;
+        Ok(page)
     }
 }
 
@@ -87,16 +127,105 @@ pub struct RankedState {
     expire_queue: Mutex<BinaryHeap<ExpireEntry>>,
     table_lookup: RwLock<Vec<String>>,
     table_indices: RwLock<HashMap<String, usize>>,
+    page_dir: String,
+    current_page: RwLock<HashMap<String, usize>>,
 }
 
 impl RankedState {
-    pub fn new() -> Self {
+    pub fn new(page_dir: String) -> Self {
+        // 페이지 디렉토리 생성
+        fs::create_dir_all(&page_dir).unwrap();
+
         RankedState {
             tables: RwLock::new(HashMap::new()),
             expire_queue: Mutex::new(BinaryHeap::new()),
             table_lookup: RwLock::new(Vec::new()),
             table_indices: RwLock::new(HashMap::new()),
+            page_dir,
+            current_page: RwLock::new(HashMap::new()),
         }
+    }
+
+    fn get_page_path(&self, table: &str, page_num: usize) -> String {
+        format!("{}/{}_{}.json", self.page_dir, table, page_num)
+    }
+
+    fn save_current_page(&self, table: &str) -> std::io::Result<()> {
+        let tables = self.tables.read().unwrap();
+        if let Some(entries) = tables.get(table) {
+            let mut page = Page::new();
+            for entry in entries.iter() {
+                page.add_entry(entry.clone());
+            }
+
+            let page_num = *self.current_page.read().unwrap().get(table).unwrap_or(&0);
+            let path = self.get_page_path(table, page_num);
+            page.save_to_file(Path::new(&path))?;
+        }
+        Ok(())
+    }
+
+    fn load_page(&self, table: &str, page_num: usize) -> std::io::Result<()> {
+        let path = self.get_page_path(table, page_num);
+        let page = Page::load_from_file(Path::new(&path))?;
+
+        let mut tables = self.tables.write().unwrap();
+        let sorted_entries = tables
+            .entry(table.to_string())
+            .or_insert_with(BTreeSet::new);
+        sorted_entries.clear();
+
+        for entry in page.entries {
+            sorted_entries.insert(entry);
+        }
+
+        Ok(())
+    }
+
+    fn check_and_save_page(&self, table: &str) -> std::io::Result<()> {
+        // 1. 현재 메모리 상태 확인
+        let (should_save, entries_to_save) = {
+            let tables = self.tables.read().unwrap();
+            if let Some(entries) = tables.get(table) {
+                if entries.len() >= MAX_MEMORY_ENTRIES {
+                    (true, entries.iter().cloned().collect::<Vec<_>>())
+                } else {
+                    (false, Vec::new())
+                }
+            } else {
+                (false, Vec::new())
+            }
+        };
+
+        if should_save {
+            // 2. 페이지 저장
+            let mut page = Page::new();
+            for entry in entries_to_save {
+                page.add_entry(entry);
+            }
+
+            let page_num = {
+                let current_page = self.current_page.read().unwrap();
+                *current_page.get(table).unwrap_or(&0)
+            };
+
+            let path = self.get_page_path(table, page_num);
+            page.save_to_file(Path::new(&path))?;
+
+            // 3. 페이지 번호 증가 및 메모리 클리어
+            {
+                let mut current_page = self.current_page.write().unwrap();
+                let page_num = current_page.entry(table.to_string()).or_insert(0);
+                *page_num += 1;
+            }
+
+            let mut tables = self.tables.write().unwrap();
+            if let Some(entries) = tables.get_mut(table) {
+                entries.clear();
+            }
+        }
+
+        Ok(())
     }
 
     fn get_table_id(&self, table: &str) -> usize {
@@ -124,31 +253,39 @@ impl RankedState {
             .unwrap()
             .as_secs();
 
-        let mut tables = self.tables.write().unwrap();
-        let mut expire_queue = self.expire_queue.lock().unwrap();
-
-        while let Some(entry) = expire_queue.peek() {
-            if entry.expire_time > now {
-                break;
+        // 1. 만료된 항목 수집
+        let expired_entries = {
+            let mut expire_queue = self.expire_queue.lock().unwrap();
+            let mut expired = Vec::new();
+            while let Some(entry) = expire_queue.peek() {
+                if entry.expire_time > now {
+                    break;
+                }
+                expired.push(expire_queue.pop().unwrap());
             }
+            expired
+        };
 
-            let entry = expire_queue.pop().unwrap();
-            let table_name = self.get_table_name(entry.table_id);
-
-            if let Some(table_name) = table_name {
-                if let Some(sorted_entries) = tables.get_mut(&table_name) {
-                    if let Some(ranked_entry) = sorted_entries.take(&RankedEntry {
-                        value: entry.value,
-                        member: entry.member.clone(),
-                        expire: None,
-                    }) {
-                        let new_value = ranked_entry.value - entry.value;
-                        if new_value > 0 {
-                            sorted_entries.insert(RankedEntry {
-                                value: new_value,
-                                member: ranked_entry.member,
-                                expire: None,
-                            });
+        // 2. 만료된 항목 처리
+        if !expired_entries.is_empty() {
+            let mut tables = self.tables.write().unwrap();
+            for entry in expired_entries {
+                let table_name = self.get_table_name(entry.table_id);
+                if let Some(table_name) = table_name {
+                    if let Some(sorted_entries) = tables.get_mut(&table_name) {
+                        if let Some(ranked_entry) = sorted_entries.take(&RankedEntry {
+                            value: entry.value,
+                            member: entry.member.clone(),
+                            expire: None,
+                        }) {
+                            let new_value = ranked_entry.value - entry.value;
+                            if new_value > 0 {
+                                sorted_entries.insert(RankedEntry {
+                                    value: new_value,
+                                    member: ranked_entry.member,
+                                    expire: None,
+                                });
+                            }
                         }
                     }
                 }
@@ -161,7 +298,7 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
 
         let entry = RankedEntry {
             value: request.value,
@@ -171,6 +308,10 @@ impl RankedState {
 
         sorted_entries.replace(entry);
 
+        // 페이지 저장 체크
+        drop(tables);
+        self.check_and_save_page(&table).unwrap();
+
         "OK".to_string()
     }
 
@@ -178,23 +319,29 @@ impl RankedState {
         self.process_expired_entries();
 
         let member = Arc::new(request.member);
-        let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        {
+            let mut tables = self.tables.write().unwrap();
+            let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
 
-        let mut entry = sorted_entries
-            .take(&RankedEntry {
-                value: 0,
-                member: member.clone(),
-                expire: None,
-            })
-            .unwrap_or_else(|| RankedEntry {
-                value: 0,
-                member: member,
-                expire: None,
-            });
+            let mut entry = sorted_entries
+                .take(&RankedEntry {
+                    value: 0,
+                    member: member.clone(),
+                    expire: None,
+                })
+                .unwrap_or_else(|| RankedEntry {
+                    value: 0,
+                    member: member,
+                    expire: None,
+                });
 
-        entry.value += request.increment;
-        sorted_entries.insert(entry);
+            entry.value += request.increment;
+            sorted_entries.insert(entry);
+
+            // 페이지 저장 체크
+            drop(tables);
+        }
+        self.check_and_save_page(&table).unwrap();
 
         "OK".to_string()
     }
@@ -210,32 +357,41 @@ impl RankedState {
         let member = Arc::new(request.member);
         let table_id = self.get_table_id(&table);
 
-        let mut tables = self.tables.write().unwrap();
-        let mut expire_queue = self.expire_queue.lock().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        // 1. 데이터 업데이트
+        {
+            let mut tables = self.tables.write().unwrap();
+            let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
 
-        let mut entry = sorted_entries
-            .take(&RankedEntry {
-                value: 0,
-                member: member.clone(),
-                expire: None,
-            })
-            .unwrap_or_else(|| RankedEntry {
-                value: 0,
-                member: member.clone(),
-                expire: None,
+            let mut entry = sorted_entries
+                .take(&RankedEntry {
+                    value: 0,
+                    member: member.clone(),
+                    expire: None,
+                })
+                .unwrap_or_else(|| RankedEntry {
+                    value: 0,
+                    member: member.clone(),
+                    expire: None,
+                });
+
+            entry.value += request.increment;
+            entry.expire = Some(now + request.expire);
+            sorted_entries.insert(entry);
+        }
+
+        // 2. 만료 큐 업데이트
+        {
+            let mut expire_queue = self.expire_queue.lock().unwrap();
+            expire_queue.push(ExpireEntry {
+                expire_time: now + request.expire,
+                table_id: table_id,
+                member: member,
+                value: request.increment,
             });
+        }
 
-        entry.value += request.increment;
-        entry.expire = Some(now + request.expire);
-        sorted_entries.insert(entry);
-
-        expire_queue.push(ExpireEntry {
-            expire_time: now + request.expire,
-            table_id: table_id,
-            member: member,
-            value: request.increment,
-        });
+        // 3. 페이지 저장 체크
+        self.check_and_save_page(&table).unwrap();
 
         "OK".to_string()
     }
@@ -243,48 +399,132 @@ impl RankedState {
     pub fn zrange(&self, table: String, request: ZRangeRequest) -> String {
         self.process_expired_entries();
 
-        let tables = self.tables.read().unwrap();
-        if let Some(sorted_entries) = tables.get(&table) {
-            let result: Vec<_> = sorted_entries
-                .iter()
-                .skip(request.offset)
-                .take(request.count)
-                .map(|entry| {
+        let mut result = Vec::new();
+        let mut remaining = request.count;
+        let mut offset = request.offset;
+
+        // 현재 메모리에 있는 데이터 처리
+        {
+            let tables = self.tables.read().unwrap();
+            if let Some(sorted_entries) = tables.get(&table) {
+                let entries: Vec<_> = sorted_entries.iter().collect();
+                let start = offset.min(entries.len());
+                let end = (start + remaining).min(entries.len());
+
+                for entry in &entries[start..end] {
                     if request.withscores {
-                        format!("{}:{}", entry.member, entry.value)
+                        result.push(format!("{}:{}", entry.member, entry.value));
                     } else {
-                        entry.member.to_string()
+                        result.push(entry.member.to_string());
                     }
-                })
-                .collect();
-            serde_json::to_string(&result).unwrap()
-        } else {
-            "[]".to_string()
+                }
+
+                remaining -= end - start;
+                offset = offset.saturating_sub(entries.len());
+            }
         }
+
+        // 디스크의 페이지 처리
+        if remaining > 0 {
+            let current_page = self.current_page.read().unwrap();
+            let mut page_num = *current_page.get(&table).unwrap_or(&0);
+
+            while remaining > 0 && page_num > 0 {
+                page_num -= 1;
+                if let Ok(_) = self.load_page(&table, page_num) {
+                    let tables = self.tables.read().unwrap();
+                    if let Some(sorted_entries) = tables.get(&table) {
+                        let entries: Vec<_> = sorted_entries.iter().collect();
+                        let start = offset.min(entries.len());
+                        let end = (start + remaining).min(entries.len());
+
+                        for entry in &entries[start..end] {
+                            if request.withscores {
+                                result.push(format!("{}:{}", entry.member, entry.value));
+                            } else {
+                                result.push(entry.member.to_string());
+                            }
+                        }
+
+                        remaining -= end - start;
+                        offset = offset.saturating_sub(entries.len());
+                    }
+                }
+            }
+        }
+
+        serde_json::to_string(&result).unwrap()
     }
 
     pub fn zrevrange(&self, table: String, request: ZRangeRequest) -> String {
         self.process_expired_entries();
 
-        let tables = self.tables.read().unwrap();
-        if let Some(sorted_entries) = tables.get(&table) {
-            let result: Vec<_> = sorted_entries
-                .iter()
-                .rev()
-                .skip(request.offset)
-                .take(request.count)
-                .map(|entry| {
-                    if request.withscores {
-                        format!("{}:{}", entry.member, entry.value)
-                    } else {
-                        entry.member.to_string()
-                    }
-                })
-                .collect();
-            serde_json::to_string(&result).unwrap()
-        } else {
-            "[]".to_string()
+        let mut result = Vec::new();
+        let mut remaining = request.count;
+        let mut offset = request.offset;
+
+        // 현재 메모리에 있는 데이터 처리
+        {
+            let tables = self.tables.read().unwrap();
+            if let Some(sorted_entries) = tables.get(&table) {
+                let entries: Vec<_> = sorted_entries.iter().rev().collect();
+                let start = offset.min(entries.len());
+                let end = (start + remaining).min(entries.len());
+
+                result = entries[start..end]
+                    .iter()
+                    .map(|entry| {
+                        if request.withscores {
+                            format!("{}:{}", entry.member, entry.value)
+                        } else {
+                            entry.member.to_string()
+                        }
+                    })
+                    .collect();
+
+                // for entry in &entries[start..end] {
+                //     if request.withscores {
+                //         result.push(format!("{}:{}", entry.member, entry.value));
+                //     } else {
+                //         result.push(entry.member.to_string());
+                //     }
+                // }
+
+                remaining -= end - start;
+                offset = offset.saturating_sub(entries.len());
+            }
         }
+
+        // 디스크의 페이지 처리
+        if remaining > 0 {
+            let current_page = self.current_page.read().unwrap();
+            let mut page_num = *current_page.get(&table).unwrap_or(&0);
+
+            while remaining > 0 && page_num > 0 {
+                page_num -= 1;
+                if let Ok(_) = self.load_page(&table, page_num) {
+                    let tables = self.tables.read().unwrap();
+                    if let Some(sorted_entries) = tables.get(&table) {
+                        let entries: Vec<_> = sorted_entries.iter().rev().collect();
+                        let start = offset.min(entries.len());
+                        let end = (start + remaining).min(entries.len());
+
+                        for entry in &entries[start..end] {
+                            if request.withscores {
+                                result.push(format!("{}:{}", entry.member, entry.value));
+                            } else {
+                                result.push(entry.member.to_string());
+                            }
+                        }
+
+                        remaining -= end - start;
+                        offset = offset.saturating_sub(entries.len());
+                    }
+                }
+            }
+        }
+
+        serde_json::to_string(&result).unwrap()
     }
 
     pub fn flushall(&self) -> String {
@@ -292,11 +532,22 @@ impl RankedState {
         let mut expire_queue = self.expire_queue.lock().unwrap();
         let mut table_indices = self.table_indices.write().unwrap();
         let mut table_lookup = self.table_lookup.write().unwrap();
+        let mut current_page = self.current_page.write().unwrap();
 
         tables.clear();
         expire_queue.clear();
         table_indices.clear();
         table_lookup.clear();
+        current_page.clear();
+
+        // 페이지 파일 삭제
+        if let Ok(entries) = fs::read_dir(&self.page_dir) {
+            for entry in entries {
+                if let Ok(entry) = entry {
+                    let _ = fs::remove_file(entry.path());
+                }
+            }
+        }
 
         "OK".to_string()
     }
@@ -310,7 +561,7 @@ mod tests {
 
     #[test]
     fn test_zadd() {
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
         let request = ZAddRequest {
             value: 100,
             member: "user1".to_string(),
@@ -328,7 +579,7 @@ mod tests {
 
     #[test]
     fn test_zincrby() {
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
         let request = ZIncrByRequest {
             increment: 10,
             member: "user1".to_string(),
@@ -346,7 +597,7 @@ mod tests {
 
     #[test]
     fn test_zincrbyp() {
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
         let request = ZIncrByPeriodRequest {
             increment: 10,
             member: "user1".to_string(),
@@ -366,7 +617,7 @@ mod tests {
 
     #[test]
     fn test_zrange() {
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
 
         // 테스트 데이터 추가
         let requests = vec![
@@ -412,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_zrevrange() {
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
 
         // 테스트 데이터 추가
         let requests = vec![
@@ -458,7 +709,7 @@ mod tests {
 
     #[test]
     fn test_flushall() {
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
 
         // 테스트 데이터 추가
         let request = ZAddRequest {
@@ -481,7 +732,7 @@ mod tests {
 
     #[test]
     fn test_concurrent_operations() {
-        let state = Arc::new(RankedState::new());
+        let state = Arc::new(RankedState::new("test".to_string()));
         let handles: Vec<_> = (0..10)
             .map(|_| {
                 let state = Arc::clone(&state);
@@ -514,7 +765,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
 
         // 만료 시간이 1초인 항목 추가
         let request = ZIncrByPeriodRequest {
@@ -546,7 +797,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
 
         // 여러 항목 추가
         let requests = vec![
@@ -601,7 +852,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
 
         // 같은 멤버에 대해 여러 번 증가
         let requests = vec![
@@ -646,7 +897,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new();
+        let state = RankedState::new("test".to_string());
 
         // 다른 테이블에 항목 추가
         let requests = vec![
@@ -699,20 +950,16 @@ mod tests {
     }
 
     #[test]
-    fn stress_test_performance() {
-        use std::sync::Arc;
-        use std::thread;
-        use std::time::Instant;
-
-        let state = Arc::new(RankedState::new());
-        let num_entries = 50_000_000;
+    fn test_page_stress() {
+        let state = Arc::new(RankedState::new("./page".to_string()));
+        let num_entries = 50_000_0;
         let num_threads = 8;
         let entries_per_thread = num_entries / num_threads;
 
-        println!("Starting stress test with {} entries...", num_entries);
+        println!("Starting page stress test with {} entries...", num_entries);
 
         // 데이터 삽입 테스트
-        let insert_start = Instant::now();
+        let insert_start = std::time::Instant::now();
         let mut handles = vec![];
 
         for thread_id in 0..num_threads {
@@ -721,12 +968,11 @@ mod tests {
                 let start = thread_id * entries_per_thread;
                 let end = start + entries_per_thread;
                 for i in start..end {
-                    let request = ZIncrByPeriodRequest {
+                    let request = ZIncrByRequest {
                         increment: (i % 1000) as i64 + 1,
                         member: format!("user{}", i),
-                        expire: 3600, // 1시간
                     };
-                    let result = state.zincrbyp("test".to_string(), request);
+                    let result = state.zincrby("test".to_string(), request);
                     assert_eq!(result, "OK");
                 }
             });
@@ -744,7 +990,12 @@ mod tests {
             num_entries as f64 / insert_duration.as_secs_f64()
         );
 
-        // zrevrange 성능 테스트
+        // 페이지 수 확인
+        let current_page = state.current_page.read().unwrap();
+        let page_count = current_page.get("test").unwrap_or(&0);
+        println!("Total pages created: {}", page_count);
+
+        // 쿼리 테스트
         let range_request = ZRangeRequest {
             offset: 0,
             count: 100,
@@ -754,7 +1005,7 @@ mod tests {
         // 100번 반복 테스트
         let mut total_query_duration = Duration::new(0, 0);
         for _ in 0..100 {
-            let query_start = Instant::now();
+            let query_start = std::time::Instant::now();
             let _result = state.zrevrange("test".to_string(), range_request.clone());
             total_query_duration += query_start.elapsed();
         }
@@ -772,53 +1023,22 @@ mod tests {
         // 메모리 사용량 확인
         let tables = state.tables.read().unwrap();
         let sorted_entries = tables.get("test").unwrap();
-        println!("Total entries in memory: {}", sorted_entries.len());
-
-        let size_of_ranked_entry = std::mem::size_of::<RankedEntry>();
-        let size_of_expire_entry = std::mem::size_of::<ExpireEntry>();
-
+        println!("Current entries in memory: {}", sorted_entries.len());
         println!(
-            "Memory usage per RankedEntry: ~{} bytes",
-            size_of_ranked_entry
-        );
-        println!(
-            "Memory usage per ExpireEntry: ~{} bytes",
-            size_of_expire_entry
+            "Memory usage per entry: ~{} bytes",
+            std::mem::size_of::<RankedEntry>()
         );
 
-        // 메모리 최적화 수치 표시
-        let original_exp_entry_size =
-            std::mem::size_of::<String>() + std::mem::size_of::<Arc<String>>() + 16; // 16 = u64 + i64
+        // 페이지 파일 크기 확인
+        let mut total_page_size = 0;
+        for i in 0..=*page_count {
+            if let Ok(metadata) = fs::metadata(state.get_page_path("test", i)) {
+                total_page_size += metadata.len();
+            }
+        }
         println!(
-            "Memory optimization: Original ExpireEntry size: ~{} bytes",
-            original_exp_entry_size
-        );
-        println!(
-            "Memory optimization: Current ExpireEntry size: ~{} bytes",
-            size_of_expire_entry
-        );
-        println!(
-            "Memory optimization: Saving ~{} bytes per entry",
-            original_exp_entry_size - size_of_expire_entry
-        );
-        println!(
-            "Total memory saved: ~{} MB",
-            (original_exp_entry_size - size_of_expire_entry) * sorted_entries.len() / (1024 * 1024)
-        );
-
-        // 만료 큐 크기 확인
-        let expire_queue = state.expire_queue.lock().unwrap();
-        println!("Total entries in expire queue: {}", expire_queue.len());
-
-        // 테이블 관련 메모리 사용량
-        let table_indices = state.table_indices.read().unwrap();
-        let table_lookup = state.table_lookup.read().unwrap();
-        println!("Number of unique tables: {}", table_lookup.len());
-        println!(
-            "Memory usage for table management: ~{} KB",
-            (table_indices.len() * (std::mem::size_of::<String>() + std::mem::size_of::<usize>())
-                + table_lookup.len() * std::mem::size_of::<String>())
-                / 1024
+            "Total page file size: {} MB",
+            total_page_size / (1024 * 1024)
         );
     }
 }

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -1,10 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BTreeSet, BinaryHeap, HashMap};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-use crate::indexableset::IndexableSet;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -85,7 +83,7 @@ pub struct ZRangeRequest {
 
 #[allow(clippy::type_complexity)]
 pub struct RankedState {
-    tables: RwLock<HashMap<String, IndexableSet<RankedEntry>>>,
+    tables: RwLock<HashMap<String, BTreeSet<RankedEntry>>>,
     expire_queue: Mutex<BinaryHeap<ExpireEntry>>,
     table_lookup: RwLock<Vec<String>>,
     table_indices: RwLock<HashMap<String, usize>>,
@@ -163,7 +161,7 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(IndexableSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
         let entry = RankedEntry {
             value: request.value,
@@ -181,7 +179,7 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(IndexableSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
         let mut entry = sorted_entries
             .take(&RankedEntry {
@@ -214,7 +212,7 @@ impl RankedState {
 
         let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(IndexableSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
         let mut entry = sorted_entries
             .take(&RankedEntry {
@@ -248,7 +246,9 @@ impl RankedState {
         let tables = self.tables.read().unwrap();
         if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
-                .range_iter(request.offset..request.offset + request.count)
+                .iter()
+                .skip(request.offset)
+                .take(request.count)
                 .map(|entry| {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)
@@ -269,8 +269,10 @@ impl RankedState {
         let tables = self.tables.read().unwrap();
         if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
-                .range_iter(request.offset..request.offset + request.count)
-                // .rev() // TODO: 수정
+                .iter()
+                .rev()
+                .skip(request.offset)
+                .take(request.count)
                 .map(|entry| {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -1,13 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, BinaryHeap, HashMap};
-use std::fs;
-use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-const PAGE_SIZE: usize = 5_000_00000;
-const MAX_MEMORY_ENTRIES: usize = 2_000_00000; // 약 2GB 제한
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -37,41 +32,6 @@ impl Ord for RankedEntry {
             Ordering::Equal => self.member.cmp(&other.member),
             ordering => ordering,
         }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct Page {
-    entries: Vec<RankedEntry>,
-    min_value: i64,
-    max_value: i64,
-}
-
-impl Page {
-    fn new() -> Self {
-        Page {
-            entries: Vec::with_capacity(PAGE_SIZE),
-            min_value: i64::MAX,
-            max_value: i64::MIN,
-        }
-    }
-
-    fn add_entry(&mut self, entry: RankedEntry) {
-        self.min_value = self.min_value.min(entry.value);
-        self.max_value = self.max_value.max(entry.value);
-        self.entries.push(entry);
-    }
-
-    fn save_to_file(&self, path: &Path) -> std::io::Result<()> {
-        let json = serde_json::to_string(self)?;
-        fs::write(path, json)?;
-        Ok(())
-    }
-
-    fn load_from_file(path: &Path) -> std::io::Result<Self> {
-        let json = fs::read_to_string(path)?;
-        let page: Page = serde_json::from_str(&json)?;
-        Ok(page)
     }
 }
 
@@ -127,105 +87,16 @@ pub struct RankedState {
     expire_queue: Mutex<BinaryHeap<ExpireEntry>>,
     table_lookup: RwLock<Vec<String>>,
     table_indices: RwLock<HashMap<String, usize>>,
-    page_dir: String,
-    current_page: RwLock<HashMap<String, usize>>,
 }
 
 impl RankedState {
-    pub fn new(page_dir: String) -> Self {
-        // 페이지 디렉토리 생성
-        fs::create_dir_all(&page_dir).unwrap();
-
+    pub fn new() -> Self {
         RankedState {
             tables: RwLock::new(HashMap::new()),
             expire_queue: Mutex::new(BinaryHeap::new()),
             table_lookup: RwLock::new(Vec::new()),
             table_indices: RwLock::new(HashMap::new()),
-            page_dir,
-            current_page: RwLock::new(HashMap::new()),
         }
-    }
-
-    fn get_page_path(&self, table: &str, page_num: usize) -> String {
-        format!("{}/{}_{}.json", self.page_dir, table, page_num)
-    }
-
-    fn save_current_page(&self, table: &str) -> std::io::Result<()> {
-        let tables = self.tables.read().unwrap();
-        if let Some(entries) = tables.get(table) {
-            let mut page = Page::new();
-            for entry in entries.iter() {
-                page.add_entry(entry.clone());
-            }
-
-            let page_num = *self.current_page.read().unwrap().get(table).unwrap_or(&0);
-            let path = self.get_page_path(table, page_num);
-            page.save_to_file(Path::new(&path))?;
-        }
-        Ok(())
-    }
-
-    fn load_page(&self, table: &str, page_num: usize) -> std::io::Result<()> {
-        let path = self.get_page_path(table, page_num);
-        let page = Page::load_from_file(Path::new(&path))?;
-
-        let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables
-            .entry(table.to_string())
-            .or_insert_with(BTreeSet::new);
-        sorted_entries.clear();
-
-        for entry in page.entries {
-            sorted_entries.insert(entry);
-        }
-
-        Ok(())
-    }
-
-    fn check_and_save_page(&self, table: &str) -> std::io::Result<()> {
-        // 1. 현재 메모리 상태 확인
-        let (should_save, entries_to_save) = {
-            let tables = self.tables.read().unwrap();
-            if let Some(entries) = tables.get(table) {
-                if entries.len() >= MAX_MEMORY_ENTRIES {
-                    (true, entries.iter().cloned().collect::<Vec<_>>())
-                } else {
-                    (false, Vec::new())
-                }
-            } else {
-                (false, Vec::new())
-            }
-        };
-
-        if should_save {
-            // 2. 페이지 저장
-            let mut page = Page::new();
-            for entry in entries_to_save {
-                page.add_entry(entry);
-            }
-
-            let page_num = {
-                let current_page = self.current_page.read().unwrap();
-                *current_page.get(table).unwrap_or(&0)
-            };
-
-            let path = self.get_page_path(table, page_num);
-            page.save_to_file(Path::new(&path))?;
-
-            // 3. 페이지 번호 증가 및 메모리 클리어
-            {
-                let mut current_page = self.current_page.write().unwrap();
-                let page_num = current_page.entry(table.to_string()).or_insert(0);
-                *page_num += 1;
-            }
-
-            let mut tables = self.tables.write().unwrap();
-            if let Some(entries) = tables.get_mut(table) {
-                entries.clear();
-            }
-        }
-
-        Ok(())
     }
 
     fn get_table_id(&self, table: &str) -> usize {
@@ -253,39 +124,31 @@ impl RankedState {
             .unwrap()
             .as_secs();
 
-        // 1. 만료된 항목 수집
-        let expired_entries = {
-            let mut expire_queue = self.expire_queue.lock().unwrap();
-            let mut expired = Vec::new();
-            while let Some(entry) = expire_queue.peek() {
-                if entry.expire_time > now {
-                    break;
-                }
-                expired.push(expire_queue.pop().unwrap());
-            }
-            expired
-        };
+        let mut tables = self.tables.write().unwrap();
+        let mut expire_queue = self.expire_queue.lock().unwrap();
 
-        // 2. 만료된 항목 처리
-        if !expired_entries.is_empty() {
-            let mut tables = self.tables.write().unwrap();
-            for entry in expired_entries {
-                let table_name = self.get_table_name(entry.table_id);
-                if let Some(table_name) = table_name {
-                    if let Some(sorted_entries) = tables.get_mut(&table_name) {
-                        if let Some(ranked_entry) = sorted_entries.take(&RankedEntry {
-                            value: entry.value,
-                            member: entry.member.clone(),
-                            expire: None,
-                        }) {
-                            let new_value = ranked_entry.value - entry.value;
-                            if new_value > 0 {
-                                sorted_entries.insert(RankedEntry {
-                                    value: new_value,
-                                    member: ranked_entry.member,
-                                    expire: None,
-                                });
-                            }
+        while let Some(entry) = expire_queue.peek() {
+            if entry.expire_time > now {
+                break;
+            }
+
+            let entry = expire_queue.pop().unwrap();
+            let table_name = self.get_table_name(entry.table_id);
+
+            if let Some(table_name) = table_name {
+                if let Some(sorted_entries) = tables.get_mut(&table_name) {
+                    if let Some(ranked_entry) = sorted_entries.take(&RankedEntry {
+                        value: entry.value,
+                        member: entry.member.clone(),
+                        expire: None,
+                    }) {
+                        let new_value = ranked_entry.value - entry.value;
+                        if new_value > 0 {
+                            sorted_entries.insert(RankedEntry {
+                                value: new_value,
+                                member: ranked_entry.member,
+                                expire: None,
+                            });
                         }
                     }
                 }
@@ -298,7 +161,7 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
         let entry = RankedEntry {
             value: request.value,
@@ -308,10 +171,6 @@ impl RankedState {
 
         sorted_entries.replace(entry);
 
-        // 페이지 저장 체크
-        drop(tables);
-        self.check_and_save_page(&table).unwrap();
-
         "OK".to_string()
     }
 
@@ -319,29 +178,23 @@ impl RankedState {
         self.process_expired_entries();
 
         let member = Arc::new(request.member);
-        {
-            let mut tables = self.tables.write().unwrap();
-            let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
+        let mut tables = self.tables.write().unwrap();
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
-            let mut entry = sorted_entries
-                .take(&RankedEntry {
-                    value: 0,
-                    member: member.clone(),
-                    expire: None,
-                })
-                .unwrap_or_else(|| RankedEntry {
-                    value: 0,
-                    member: member,
-                    expire: None,
-                });
+        let mut entry = sorted_entries
+            .take(&RankedEntry {
+                value: 0,
+                member: member.clone(),
+                expire: None,
+            })
+            .unwrap_or_else(|| RankedEntry {
+                value: 0,
+                member: member,
+                expire: None,
+            });
 
-            entry.value += request.increment;
-            sorted_entries.insert(entry);
-
-            // 페이지 저장 체크
-            drop(tables);
-        }
-        self.check_and_save_page(&table).unwrap();
+        entry.value += request.increment;
+        sorted_entries.insert(entry);
 
         "OK".to_string()
     }
@@ -357,41 +210,32 @@ impl RankedState {
         let member = Arc::new(request.member);
         let table_id = self.get_table_id(&table);
 
-        // 1. 데이터 업데이트
-        {
-            let mut tables = self.tables.write().unwrap();
-            let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
+        let mut tables = self.tables.write().unwrap();
+        let mut expire_queue = self.expire_queue.lock().unwrap();
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
-            let mut entry = sorted_entries
-                .take(&RankedEntry {
-                    value: 0,
-                    member: member.clone(),
-                    expire: None,
-                })
-                .unwrap_or_else(|| RankedEntry {
-                    value: 0,
-                    member: member.clone(),
-                    expire: None,
-                });
-
-            entry.value += request.increment;
-            entry.expire = Some(now + request.expire);
-            sorted_entries.insert(entry);
-        }
-
-        // 2. 만료 큐 업데이트
-        {
-            let mut expire_queue = self.expire_queue.lock().unwrap();
-            expire_queue.push(ExpireEntry {
-                expire_time: now + request.expire,
-                table_id: table_id,
-                member: member,
-                value: request.increment,
+        let mut entry = sorted_entries
+            .take(&RankedEntry {
+                value: 0,
+                member: member.clone(),
+                expire: None,
+            })
+            .unwrap_or_else(|| RankedEntry {
+                value: 0,
+                member: member.clone(),
+                expire: None,
             });
-        }
 
-        // 3. 페이지 저장 체크
-        self.check_and_save_page(&table).unwrap();
+        entry.value += request.increment;
+        entry.expire = Some(now + request.expire);
+        sorted_entries.insert(entry);
+
+        expire_queue.push(ExpireEntry {
+            expire_time: now + request.expire,
+            table_id: table_id,
+            member: member,
+            value: request.increment,
+        });
 
         "OK".to_string()
     }
@@ -399,132 +243,48 @@ impl RankedState {
     pub fn zrange(&self, table: String, request: ZRangeRequest) -> String {
         self.process_expired_entries();
 
-        let mut result = Vec::new();
-        let mut remaining = request.count;
-        let mut offset = request.offset;
-
-        // 현재 메모리에 있는 데이터 처리
-        {
-            let tables = self.tables.read().unwrap();
-            if let Some(sorted_entries) = tables.get(&table) {
-                let entries: Vec<_> = sorted_entries.iter().collect();
-                let start = offset.min(entries.len());
-                let end = (start + remaining).min(entries.len());
-
-                for entry in &entries[start..end] {
+        let tables = self.tables.read().unwrap();
+        if let Some(sorted_entries) = tables.get(&table) {
+            let result: Vec<_> = sorted_entries
+                .iter()
+                .skip(request.offset)
+                .take(request.count)
+                .map(|entry| {
                     if request.withscores {
-                        result.push(format!("{}:{}", entry.member, entry.value));
+                        format!("{}:{}", entry.member, entry.value)
                     } else {
-                        result.push(entry.member.to_string());
+                        entry.member.to_string()
                     }
-                }
-
-                remaining -= end - start;
-                offset = offset.saturating_sub(entries.len());
-            }
+                })
+                .collect();
+            serde_json::to_string(&result).unwrap()
+        } else {
+            "[]".to_string()
         }
-
-        // 디스크의 페이지 처리
-        if remaining > 0 {
-            let current_page = self.current_page.read().unwrap();
-            let mut page_num = *current_page.get(&table).unwrap_or(&0);
-
-            while remaining > 0 && page_num > 0 {
-                page_num -= 1;
-                if let Ok(_) = self.load_page(&table, page_num) {
-                    let tables = self.tables.read().unwrap();
-                    if let Some(sorted_entries) = tables.get(&table) {
-                        let entries: Vec<_> = sorted_entries.iter().collect();
-                        let start = offset.min(entries.len());
-                        let end = (start + remaining).min(entries.len());
-
-                        for entry in &entries[start..end] {
-                            if request.withscores {
-                                result.push(format!("{}:{}", entry.member, entry.value));
-                            } else {
-                                result.push(entry.member.to_string());
-                            }
-                        }
-
-                        remaining -= end - start;
-                        offset = offset.saturating_sub(entries.len());
-                    }
-                }
-            }
-        }
-
-        serde_json::to_string(&result).unwrap()
     }
 
     pub fn zrevrange(&self, table: String, request: ZRangeRequest) -> String {
         self.process_expired_entries();
 
-        let mut result = Vec::new();
-        let mut remaining = request.count;
-        let mut offset = request.offset;
-
-        // 현재 메모리에 있는 데이터 처리
-        {
-            let tables = self.tables.read().unwrap();
-            if let Some(sorted_entries) = tables.get(&table) {
-                let entries: Vec<_> = sorted_entries.iter().rev().collect();
-                let start = offset.min(entries.len());
-                let end = (start + remaining).min(entries.len());
-
-                result = entries[start..end]
-                    .iter()
-                    .map(|entry| {
-                        if request.withscores {
-                            format!("{}:{}", entry.member, entry.value)
-                        } else {
-                            entry.member.to_string()
-                        }
-                    })
-                    .collect();
-
-                // for entry in &entries[start..end] {
-                //     if request.withscores {
-                //         result.push(format!("{}:{}", entry.member, entry.value));
-                //     } else {
-                //         result.push(entry.member.to_string());
-                //     }
-                // }
-
-                remaining -= end - start;
-                offset = offset.saturating_sub(entries.len());
-            }
-        }
-
-        // 디스크의 페이지 처리
-        if remaining > 0 {
-            let current_page = self.current_page.read().unwrap();
-            let mut page_num = *current_page.get(&table).unwrap_or(&0);
-
-            while remaining > 0 && page_num > 0 {
-                page_num -= 1;
-                if let Ok(_) = self.load_page(&table, page_num) {
-                    let tables = self.tables.read().unwrap();
-                    if let Some(sorted_entries) = tables.get(&table) {
-                        let entries: Vec<_> = sorted_entries.iter().rev().collect();
-                        let start = offset.min(entries.len());
-                        let end = (start + remaining).min(entries.len());
-
-                        for entry in &entries[start..end] {
-                            if request.withscores {
-                                result.push(format!("{}:{}", entry.member, entry.value));
-                            } else {
-                                result.push(entry.member.to_string());
-                            }
-                        }
-
-                        remaining -= end - start;
-                        offset = offset.saturating_sub(entries.len());
+        let tables = self.tables.read().unwrap();
+        if let Some(sorted_entries) = tables.get(&table) {
+            let result: Vec<_> = sorted_entries
+                .iter()
+                .rev()
+                .skip(request.offset)
+                .take(request.count)
+                .map(|entry| {
+                    if request.withscores {
+                        format!("{}:{}", entry.member, entry.value)
+                    } else {
+                        entry.member.to_string()
                     }
-                }
-            }
+                })
+                .collect();
+            serde_json::to_string(&result).unwrap()
+        } else {
+            "[]".to_string()
         }
-
-        serde_json::to_string(&result).unwrap()
     }
 
     pub fn flushall(&self) -> String {
@@ -532,22 +292,11 @@ impl RankedState {
         let mut expire_queue = self.expire_queue.lock().unwrap();
         let mut table_indices = self.table_indices.write().unwrap();
         let mut table_lookup = self.table_lookup.write().unwrap();
-        let mut current_page = self.current_page.write().unwrap();
 
         tables.clear();
         expire_queue.clear();
         table_indices.clear();
         table_lookup.clear();
-        current_page.clear();
-
-        // 페이지 파일 삭제
-        if let Ok(entries) = fs::read_dir(&self.page_dir) {
-            for entry in entries {
-                if let Ok(entry) = entry {
-                    let _ = fs::remove_file(entry.path());
-                }
-            }
-        }
 
         "OK".to_string()
     }
@@ -561,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_zadd() {
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
         let request = ZAddRequest {
             value: 100,
             member: "user1".to_string(),
@@ -579,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_zincrby() {
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
         let request = ZIncrByRequest {
             increment: 10,
             member: "user1".to_string(),
@@ -597,7 +346,7 @@ mod tests {
 
     #[test]
     fn test_zincrbyp() {
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
         let request = ZIncrByPeriodRequest {
             increment: 10,
             member: "user1".to_string(),
@@ -617,7 +366,7 @@ mod tests {
 
     #[test]
     fn test_zrange() {
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
 
         // 테스트 데이터 추가
         let requests = vec![
@@ -663,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_zrevrange() {
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
 
         // 테스트 데이터 추가
         let requests = vec![
@@ -709,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_flushall() {
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
 
         // 테스트 데이터 추가
         let request = ZAddRequest {
@@ -732,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_concurrent_operations() {
-        let state = Arc::new(RankedState::new("test".to_string()));
+        let state = Arc::new(RankedState::new());
         let handles: Vec<_> = (0..10)
             .map(|_| {
                 let state = Arc::clone(&state);
@@ -765,7 +514,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
 
         // 만료 시간이 1초인 항목 추가
         let request = ZIncrByPeriodRequest {
@@ -797,7 +546,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
 
         // 여러 항목 추가
         let requests = vec![
@@ -852,7 +601,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
 
         // 같은 멤버에 대해 여러 번 증가
         let requests = vec![
@@ -897,7 +646,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let state = RankedState::new("test".to_string());
+        let state = RankedState::new();
 
         // 다른 테이블에 항목 추가
         let requests = vec![
@@ -950,16 +699,20 @@ mod tests {
     }
 
     #[test]
-    fn test_page_stress() {
-        let state = Arc::new(RankedState::new("./page".to_string()));
-        let num_entries = 50_000_0;
+    fn stress_test_performance() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::Instant;
+
+        let state = Arc::new(RankedState::new());
+        let num_entries = 50_000_000;
         let num_threads = 8;
         let entries_per_thread = num_entries / num_threads;
 
-        println!("Starting page stress test with {} entries...", num_entries);
+        println!("Starting stress test with {} entries...", num_entries);
 
         // 데이터 삽입 테스트
-        let insert_start = std::time::Instant::now();
+        let insert_start = Instant::now();
         let mut handles = vec![];
 
         for thread_id in 0..num_threads {
@@ -968,11 +721,12 @@ mod tests {
                 let start = thread_id * entries_per_thread;
                 let end = start + entries_per_thread;
                 for i in start..end {
-                    let request = ZIncrByRequest {
+                    let request = ZIncrByPeriodRequest {
                         increment: (i % 1000) as i64 + 1,
                         member: format!("user{}", i),
+                        expire: 3600, // 1시간
                     };
-                    let result = state.zincrby("test".to_string(), request);
+                    let result = state.zincrbyp("test".to_string(), request);
                     assert_eq!(result, "OK");
                 }
             });
@@ -990,12 +744,7 @@ mod tests {
             num_entries as f64 / insert_duration.as_secs_f64()
         );
 
-        // 페이지 수 확인
-        let current_page = state.current_page.read().unwrap();
-        let page_count = current_page.get("test").unwrap_or(&0);
-        println!("Total pages created: {}", page_count);
-
-        // 쿼리 테스트
+        // zrevrange 성능 테스트
         let range_request = ZRangeRequest {
             offset: 0,
             count: 100,
@@ -1005,7 +754,7 @@ mod tests {
         // 100번 반복 테스트
         let mut total_query_duration = Duration::new(0, 0);
         for _ in 0..100 {
-            let query_start = std::time::Instant::now();
+            let query_start = Instant::now();
             let _result = state.zrevrange("test".to_string(), range_request.clone());
             total_query_duration += query_start.elapsed();
         }
@@ -1023,22 +772,53 @@ mod tests {
         // 메모리 사용량 확인
         let tables = state.tables.read().unwrap();
         let sorted_entries = tables.get("test").unwrap();
-        println!("Current entries in memory: {}", sorted_entries.len());
+        println!("Total entries in memory: {}", sorted_entries.len());
+
+        let size_of_ranked_entry = std::mem::size_of::<RankedEntry>();
+        let size_of_expire_entry = std::mem::size_of::<ExpireEntry>();
+
         println!(
-            "Memory usage per entry: ~{} bytes",
-            std::mem::size_of::<RankedEntry>()
+            "Memory usage per RankedEntry: ~{} bytes",
+            size_of_ranked_entry
+        );
+        println!(
+            "Memory usage per ExpireEntry: ~{} bytes",
+            size_of_expire_entry
         );
 
-        // 페이지 파일 크기 확인
-        let mut total_page_size = 0;
-        for i in 0..=*page_count {
-            if let Ok(metadata) = fs::metadata(state.get_page_path("test", i)) {
-                total_page_size += metadata.len();
-            }
-        }
+        // 메모리 최적화 수치 표시
+        let original_exp_entry_size =
+            std::mem::size_of::<String>() + std::mem::size_of::<Arc<String>>() + 16; // 16 = u64 + i64
         println!(
-            "Total page file size: {} MB",
-            total_page_size / (1024 * 1024)
+            "Memory optimization: Original ExpireEntry size: ~{} bytes",
+            original_exp_entry_size
+        );
+        println!(
+            "Memory optimization: Current ExpireEntry size: ~{} bytes",
+            size_of_expire_entry
+        );
+        println!(
+            "Memory optimization: Saving ~{} bytes per entry",
+            original_exp_entry_size - size_of_expire_entry
+        );
+        println!(
+            "Total memory saved: ~{} MB",
+            (original_exp_entry_size - size_of_expire_entry) * sorted_entries.len() / (1024 * 1024)
+        );
+
+        // 만료 큐 크기 확인
+        let expire_queue = state.expire_queue.lock().unwrap();
+        println!("Total entries in expire queue: {}", expire_queue.len());
+
+        // 테이블 관련 메모리 사용량
+        let table_indices = state.table_indices.read().unwrap();
+        let table_lookup = state.table_lookup.read().unwrap();
+        println!("Number of unique tables: {}", table_lookup.len());
+        println!(
+            "Memory usage for table management: ~{} KB",
+            (table_indices.len() * (std::mem::size_of::<String>() + std::mem::size_of::<usize>())
+                + table_lookup.len() * std::mem::size_of::<String>())
+                / 1024
         );
     }
 }

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const PAGE_SIZE: usize = 5_000_000;
-const MAX_MEMORY_ENTRIES: usize = 5_000_000; // 약 2GB 제한
+const PAGE_SIZE: usize = 5_000_00;
+const MAX_MEMORY_ENTRIES: usize = 3_000_00; // 약 2GB 제한
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -63,14 +63,31 @@ impl Page {
     }
 
     fn save_to_file(&self, path: &Path) -> std::io::Result<()> {
-        let json = serde_json::to_string(self)?;
+        let entries: Vec<_> = self
+            .entries
+            .iter()
+            .map(|entry| {
+                let member = entry.member.as_ref().clone();
+                (entry.value, member, entry.expire)
+            })
+            .collect();
+        let json = serde_json::to_string(&entries)?;
         fs::write(path, json)?;
         Ok(())
     }
 
     fn load_from_file(path: &Path) -> std::io::Result<Self> {
         let json = fs::read_to_string(path)?;
-        let page: Page = serde_json::from_str(&json)?;
+        let entries: Vec<(i64, String, Option<u64>)> = serde_json::from_str(&json)?;
+
+        let mut page = Page::new();
+        for (value, member, expire) in entries {
+            page.add_entry(RankedEntry {
+                value,
+                member: Arc::new(member),
+                expire,
+            });
+        }
         Ok(page)
     }
 }
@@ -403,52 +420,95 @@ impl RankedState {
         let mut remaining = request.count;
         let mut offset = request.offset;
 
-        // 현재 메모리에 있는 데이터 처리
+        // 1. 메모리에 있는 데이터 처리
         {
             let tables = self.tables.read().unwrap();
             if let Some(sorted_entries) = tables.get(&table) {
-                let entries: Vec<_> = sorted_entries.iter().collect();
-                let start = offset.min(entries.len());
-                let end = (start + remaining).min(entries.len());
+                // 메모리에 있는 데이터의 범위 확인
+                let memory_min = sorted_entries.first().map(|e| e.value).unwrap_or(i64::MAX);
+                let memory_max = sorted_entries.last().map(|e| e.value).unwrap_or(i64::MIN);
 
-                for entry in &entries[start..end] {
-                    if request.withscores {
-                        result.push(format!("{}:{}", entry.member, entry.value));
-                    } else {
-                        result.push(entry.member.to_string());
+                // 현재 페이지 번호 확인
+                let current_page = self.current_page.read().unwrap();
+                let page_num = *current_page.get(&table).unwrap_or(&0);
+
+                // 디스크의 페이지들을 확인하여 정렬 순서 결정
+                let mut disk_pages = Vec::new();
+                for i in 0..page_num {
+                    if let Ok(page) =
+                        Page::load_from_file(Path::new(&self.get_page_path(&table, i)))
+                    {
+                        disk_pages.push((i, page.min_value, page.max_value));
                     }
                 }
 
-                remaining -= end - start;
-                offset = offset.saturating_sub(entries.len());
+                // 메모리 데이터가 처리될 위치 계산
+                let mut memory_start = 0;
+                let mut memory_end = sorted_entries.len();
+
+                // 디스크 페이지 중 메모리 데이터보다 작은 값이 있는지 확인
+                for (_, min, max) in &disk_pages {
+                    if *max < memory_min {
+                        memory_start += PAGE_SIZE;
+                        memory_end += PAGE_SIZE;
+                    } else if *min > memory_max {
+                        break;
+                    }
+                }
+
+                // 메모리 데이터 처리
+                let start = offset.saturating_sub(memory_start);
+                let end = (start + remaining).min(memory_end - memory_start);
+
+                if start < sorted_entries.len() {
+                    result = sorted_entries
+                        .iter()
+                        .skip(start)
+                        .take(end - start)
+                        .map(|entry| {
+                            if request.withscores {
+                                format!("{}:{}", entry.member, entry.value)
+                            } else {
+                                entry.member.to_string()
+                            }
+                        })
+                        .collect();
+
+                    remaining -= end - start;
+                    offset = offset.saturating_sub(memory_end);
+                }
             }
         }
 
-        // 디스크의 페이지 처리
+        // 2. 디스크의 페이지 처리
         if remaining > 0 {
             let current_page = self.current_page.read().unwrap();
             let mut page_num = *current_page.get(&table).unwrap_or(&0);
 
             while remaining > 0 && page_num > 0 {
                 page_num -= 1;
-                if let Ok(_) = self.load_page(&table, page_num) {
-                    let tables = self.tables.read().unwrap();
-                    if let Some(sorted_entries) = tables.get(&table) {
-                        let entries: Vec<_> = sorted_entries.iter().collect();
-                        let start = offset.min(entries.len());
-                        let end = (start + remaining).min(entries.len());
+                if let Ok(page) =
+                    Page::load_from_file(Path::new(&self.get_page_path(&table, page_num)))
+                {
+                    let start = offset.min(page.entries.len());
+                    let end = (start + remaining).min(page.entries.len());
 
-                        for entry in &entries[start..end] {
-                            if request.withscores {
-                                result.push(format!("{}:{}", entry.member, entry.value));
-                            } else {
-                                result.push(entry.member.to_string());
-                            }
-                        }
+                    result.extend(
+                        page.entries
+                            .iter()
+                            .skip(start)
+                            .take(end - start)
+                            .map(|entry| {
+                                if request.withscores {
+                                    format!("{}:{}", entry.member, entry.value)
+                                } else {
+                                    entry.member.to_string()
+                                }
+                            }),
+                    );
 
-                        remaining -= end - start;
-                        offset = offset.saturating_sub(entries.len());
-                    }
+                    remaining -= end - start;
+                    offset = offset.saturating_sub(page.entries.len());
                 }
             }
         }
@@ -1012,7 +1072,7 @@ mod tests {
             };
 
             let query_start = std::time::Instant::now();
-            let _result = state.zrevrange("test".to_string(), range_request);
+            let _result = state.zrange("test".to_string(), range_request);
             total_query_duration += query_start.elapsed();
         }
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -38,7 +38,7 @@ impl Ord for RankedEntry {
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct ExpireEntry {
     expire_time: u64,
-    table: String,
+    table_id: usize,
     member: Arc<String>,
     value: i64,
 }
@@ -85,6 +85,8 @@ pub struct ZRangeRequest {
 pub struct RankedState {
     tables: RwLock<HashMap<String, BTreeSet<RankedEntry>>>,
     expire_queue: Mutex<BinaryHeap<ExpireEntry>>,
+    table_lookup: RwLock<Vec<String>>,
+    table_indices: RwLock<HashMap<String, usize>>,
 }
 
 impl RankedState {
@@ -92,7 +94,28 @@ impl RankedState {
         RankedState {
             tables: RwLock::new(HashMap::new()),
             expire_queue: Mutex::new(BinaryHeap::new()),
+            table_lookup: RwLock::new(Vec::new()),
+            table_indices: RwLock::new(HashMap::new()),
         }
+    }
+
+    fn get_table_id(&self, table: &str) -> usize {
+        let mut indices = self.table_indices.write().unwrap();
+        let mut lookup = self.table_lookup.write().unwrap();
+
+        if let Some(&index) = indices.get(table) {
+            return index;
+        }
+
+        let new_index = lookup.len();
+        lookup.push(table.to_string());
+        indices.insert(table.to_string(), new_index);
+        new_index
+    }
+
+    fn get_table_name(&self, id: usize) -> Option<String> {
+        let lookup = self.table_lookup.read().unwrap();
+        lookup.get(id).cloned()
     }
 
     fn process_expired_entries(&self) {
@@ -110,20 +133,23 @@ impl RankedState {
             }
 
             let entry = expire_queue.pop().unwrap();
+            let table_name = self.get_table_name(entry.table_id);
 
-            if let Some(sorted_entries) = tables.get_mut(&entry.table) {
-                if let Some(ranked_entry) = sorted_entries.take(&RankedEntry {
-                    value: entry.value,
-                    member: entry.member.clone(),
-                    expire: None,
-                }) {
-                    let new_value = ranked_entry.value - entry.value;
-                    if new_value > 0 {
-                        sorted_entries.insert(RankedEntry {
-                            value: new_value,
-                            member: ranked_entry.member,
-                            expire: None,
-                        });
+            if let Some(table_name) = table_name {
+                if let Some(sorted_entries) = tables.get_mut(&table_name) {
+                    if let Some(ranked_entry) = sorted_entries.take(&RankedEntry {
+                        value: entry.value,
+                        member: entry.member.clone(),
+                        expire: None,
+                    }) {
+                        let new_value = ranked_entry.value - entry.value;
+                        if new_value > 0 {
+                            sorted_entries.insert(RankedEntry {
+                                value: new_value,
+                                member: ranked_entry.member,
+                                expire: None,
+                            });
+                        }
                     }
                 }
             }
@@ -182,9 +208,11 @@ impl RankedState {
             .as_secs();
 
         let member = Arc::new(request.member);
+        let table_id = self.get_table_id(&table);
+
         let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
-        let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
         let mut entry = sorted_entries
             .take(&RankedEntry {
@@ -204,7 +232,7 @@ impl RankedState {
 
         expire_queue.push(ExpireEntry {
             expire_time: now + request.expire,
-            table: table,
+            table_id: table_id,
             member: member,
             value: request.increment,
         });
@@ -262,8 +290,14 @@ impl RankedState {
     pub fn flushall(&self) -> String {
         let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
+        let mut table_indices = self.table_indices.write().unwrap();
+        let mut table_lookup = self.table_lookup.write().unwrap();
+
         tables.clear();
         expire_queue.clear();
+        table_indices.clear();
+        table_lookup.clear();
+
         "OK".to_string()
     }
 }
@@ -739,13 +773,52 @@ mod tests {
         let tables = state.tables.read().unwrap();
         let sorted_entries = tables.get("test").unwrap();
         println!("Total entries in memory: {}", sorted_entries.len());
+
+        let size_of_ranked_entry = std::mem::size_of::<RankedEntry>();
+        let size_of_expire_entry = std::mem::size_of::<ExpireEntry>();
+
         println!(
-            "Memory usage per entry: ~{} bytes",
-            std::mem::size_of::<RankedEntry>() + std::mem::size_of::<String>() * 2
-        ); // member와 table 문자열의 평균 크기
+            "Memory usage per RankedEntry: ~{} bytes",
+            size_of_ranked_entry
+        );
+        println!(
+            "Memory usage per ExpireEntry: ~{} bytes",
+            size_of_expire_entry
+        );
+
+        // 메모리 최적화 수치 표시
+        let original_exp_entry_size =
+            std::mem::size_of::<String>() + std::mem::size_of::<Arc<String>>() + 16; // 16 = u64 + i64
+        println!(
+            "Memory optimization: Original ExpireEntry size: ~{} bytes",
+            original_exp_entry_size
+        );
+        println!(
+            "Memory optimization: Current ExpireEntry size: ~{} bytes",
+            size_of_expire_entry
+        );
+        println!(
+            "Memory optimization: Saving ~{} bytes per entry",
+            original_exp_entry_size - size_of_expire_entry
+        );
+        println!(
+            "Total memory saved: ~{} MB",
+            (original_exp_entry_size - size_of_expire_entry) * sorted_entries.len() / (1024 * 1024)
+        );
 
         // 만료 큐 크기 확인
         let expire_queue = state.expire_queue.lock().unwrap();
         println!("Total entries in expire queue: {}", expire_queue.len());
+
+        // 테이블 관련 메모리 사용량
+        let table_indices = state.table_indices.read().unwrap();
+        let table_lookup = state.table_lookup.read().unwrap();
+        println!("Number of unique tables: {}", table_lookup.len());
+        println!(
+            "Memory usage for table management: ~{} KB",
+            (table_indices.len() * (std::mem::size_of::<String>() + std::mem::size_of::<usize>())
+                + table_lookup.len() * std::mem::size_of::<String>())
+                / 1024
+        );
     }
 }

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -523,92 +523,63 @@ impl RankedState {
         let mut remaining = request.count;
         let mut offset = request.offset;
 
-        // 1. 메모리에 있는 데이터 처리
+        // 현재 메모리에 있는 데이터 처리
         {
             let tables = self.tables.read().unwrap();
             if let Some(sorted_entries) = tables.get(&table) {
-                // 메모리에 있는 데이터의 범위 확인
-                let memory_min = sorted_entries.first().map(|e| e.value).unwrap_or(i64::MAX);
-                let memory_max = sorted_entries.last().map(|e| e.value).unwrap_or(i64::MIN);
+                let start = offset.min(sorted_entries.len());
+                let end = (start + remaining).min(sorted_entries.len());
 
-                // 현재 페이지 번호 확인
-                let current_page = self.current_page.read().unwrap();
-                let page_num = *current_page.get(&table).unwrap_or(&0);
+                result = sorted_entries
+                    .iter()
+                    .rev()
+                    .skip(start)
+                    .take(end - start)
+                    .map(|entry| {
+                        if request.withscores {
+                            format!("{}:{}", entry.member, entry.value)
+                        } else {
+                            entry.member.to_string()
+                        }
+                    })
+                    .collect();
 
-                // 디스크의 페이지들을 확인하여 정렬 순서 결정
-                let mut disk_pages = Vec::new();
-                for i in 0..page_num {
-                    if let Ok(page) =
-                        Page::load_from_file(Path::new(&self.get_page_path(&table, i)))
-                    {
-                        disk_pages.push((i, page.min_value, page.max_value));
-                    }
-                }
-
-                // 메모리 데이터가 처리될 위치 계산 (역순)
-                let mut memory_start = 0;
-                let mut memory_end = sorted_entries.len();
-
-                // 디스크 페이지 중 메모리 데이터보다 큰 값이 있는지 확인
-                for (_, min, max) in disk_pages.iter().rev() {
-                    if *min > memory_max {
-                        memory_start += PAGE_SIZE;
-                        memory_end += PAGE_SIZE;
-                    } else if *max < memory_min {
-                        break;
-                    }
-                }
-
-                // 메모리 데이터 처리 (역순)
-                let start = offset.saturating_sub(memory_start);
-                let end = (start + remaining).min(memory_end - memory_start);
-
-                if start < sorted_entries.len() {
-                    result = sorted_entries
-                        .iter()
-                        .rev()
-                        .skip(start)
-                        .take(end - start)
-                        .map(|entry| {
-                            if request.withscores {
-                                format!("{}:{}", entry.member, entry.value)
-                            } else {
-                                entry.member.to_string()
-                            }
-                        })
-                        .collect();
-
-                    remaining -= end - start;
-                    offset = offset.saturating_sub(memory_end);
-                }
+                remaining -= end - start;
+                offset = offset.saturating_sub(sorted_entries.len());
             }
         }
 
-        // 2. 디스크의 페이지 처리 (역순)
+        // 디스크의 페이지 처리
         if remaining > 0 {
             let current_page = self.current_page.read().unwrap();
             let mut page_num = *current_page.get(&table).unwrap_or(&0);
 
             while remaining > 0 && page_num > 0 {
                 page_num -= 1;
-                if let Ok(page) =
-                    Page::load_from_file(Path::new(&self.get_page_path(&table, page_num)))
-                {
-                    let start = offset.min(page.entries.len());
-                    let end = (start + remaining).min(page.entries.len());
+                if let Ok(_) = self.load_page(&table, page_num) {
+                    let tables = self.tables.read().unwrap();
+                    if let Some(sorted_entries) = tables.get(&table) {
+                        let start = offset.min(sorted_entries.len());
+                        let end = (start + remaining).min(sorted_entries.len());
 
-                    result.extend(page.entries.iter().rev().skip(start).take(end - start).map(
-                        |entry| {
-                            if request.withscores {
-                                format!("{}:{}", entry.member, entry.value)
-                            } else {
-                                entry.member.to_string()
-                            }
-                        },
-                    ));
+                        result.extend(
+                            sorted_entries
+                                .iter()
+                                .rev()
+                                .skip(start)
+                                .take(end - start)
+                                .map(|entry| {
+                                    if request.withscores {
+                                        format!("{}:{}", entry.member, entry.value)
+                                    } else {
+                                        entry.member.to_string()
+                                    }
+                                }),
+                        );
 
-                    remaining -= end - start;
-                    offset = offset.saturating_sub(page.entries.len());
+                        remaining -= end - start;
+                        offset = offset.saturating_sub(sorted_entries.len());
+                    }
                 }
             }
         }

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const PAGE_SIZE: usize = 5_000_00;
-const MAX_MEMORY_ENTRIES: usize = 3_000_00; // 약 2GB 제한
+const PAGE_SIZE: usize = 5_000_000;
+const MAX_MEMORY_ENTRIES: usize = 5_000_000; // 약 2GB 제한
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
@@ -63,31 +63,14 @@ impl Page {
     }
 
     fn save_to_file(&self, path: &Path) -> std::io::Result<()> {
-        let entries: Vec<_> = self
-            .entries
-            .iter()
-            .map(|entry| {
-                let member = entry.member.as_ref().clone();
-                (entry.value, member, entry.expire)
-            })
-            .collect();
-        let json = serde_json::to_string(&entries)?;
+        let json = serde_json::to_string(self)?;
         fs::write(path, json)?;
         Ok(())
     }
 
     fn load_from_file(path: &Path) -> std::io::Result<Self> {
         let json = fs::read_to_string(path)?;
-        let entries: Vec<(i64, String, Option<u64>)> = serde_json::from_str(&json)?;
-
-        let mut page = Page::new();
-        for (value, member, expire) in entries {
-            page.add_entry(RankedEntry {
-                value,
-                member: Arc::new(member),
-                expire,
-            });
-        }
+        let page: Page = serde_json::from_str(&json)?;
         Ok(page)
     }
 }
@@ -420,95 +403,52 @@ impl RankedState {
         let mut remaining = request.count;
         let mut offset = request.offset;
 
-        // 1. 메모리에 있는 데이터 처리
+        // 현재 메모리에 있는 데이터 처리
         {
             let tables = self.tables.read().unwrap();
             if let Some(sorted_entries) = tables.get(&table) {
-                // 메모리에 있는 데이터의 범위 확인
-                let memory_min = sorted_entries.first().map(|e| e.value).unwrap_or(i64::MAX);
-                let memory_max = sorted_entries.last().map(|e| e.value).unwrap_or(i64::MIN);
+                let entries: Vec<_> = sorted_entries.iter().collect();
+                let start = offset.min(entries.len());
+                let end = (start + remaining).min(entries.len());
 
-                // 현재 페이지 번호 확인
-                let current_page = self.current_page.read().unwrap();
-                let page_num = *current_page.get(&table).unwrap_or(&0);
-
-                // 디스크의 페이지들을 확인하여 정렬 순서 결정
-                let mut disk_pages = Vec::new();
-                for i in 0..page_num {
-                    if let Ok(page) =
-                        Page::load_from_file(Path::new(&self.get_page_path(&table, i)))
-                    {
-                        disk_pages.push((i, page.min_value, page.max_value));
+                for entry in &entries[start..end] {
+                    if request.withscores {
+                        result.push(format!("{}:{}", entry.member, entry.value));
+                    } else {
+                        result.push(entry.member.to_string());
                     }
                 }
 
-                // 메모리 데이터가 처리될 위치 계산
-                let mut memory_start = 0;
-                let mut memory_end = sorted_entries.len();
-
-                // 디스크 페이지 중 메모리 데이터보다 작은 값이 있는지 확인
-                for (_, min, max) in &disk_pages {
-                    if *max < memory_min {
-                        memory_start += PAGE_SIZE;
-                        memory_end += PAGE_SIZE;
-                    } else if *min > memory_max {
-                        break;
-                    }
-                }
-
-                // 메모리 데이터 처리
-                let start = offset.saturating_sub(memory_start);
-                let end = (start + remaining).min(memory_end - memory_start);
-
-                if start < sorted_entries.len() {
-                    result = sorted_entries
-                        .iter()
-                        .skip(start)
-                        .take(end - start)
-                        .map(|entry| {
-                            if request.withscores {
-                                format!("{}:{}", entry.member, entry.value)
-                            } else {
-                                entry.member.to_string()
-                            }
-                        })
-                        .collect();
-
-                    remaining -= end - start;
-                    offset = offset.saturating_sub(memory_end);
-                }
+                remaining -= end - start;
+                offset = offset.saturating_sub(entries.len());
             }
         }
 
-        // 2. 디스크의 페이지 처리
+        // 디스크의 페이지 처리
         if remaining > 0 {
             let current_page = self.current_page.read().unwrap();
             let mut page_num = *current_page.get(&table).unwrap_or(&0);
 
             while remaining > 0 && page_num > 0 {
                 page_num -= 1;
-                if let Ok(page) =
-                    Page::load_from_file(Path::new(&self.get_page_path(&table, page_num)))
-                {
-                    let start = offset.min(page.entries.len());
-                    let end = (start + remaining).min(page.entries.len());
+                if let Ok(_) = self.load_page(&table, page_num) {
+                    let tables = self.tables.read().unwrap();
+                    if let Some(sorted_entries) = tables.get(&table) {
+                        let entries: Vec<_> = sorted_entries.iter().collect();
+                        let start = offset.min(entries.len());
+                        let end = (start + remaining).min(entries.len());
 
-                    result.extend(
-                        page.entries
-                            .iter()
-                            .skip(start)
-                            .take(end - start)
-                            .map(|entry| {
-                                if request.withscores {
-                                    format!("{}:{}", entry.member, entry.value)
-                                } else {
-                                    entry.member.to_string()
-                                }
-                            }),
-                    );
+                        for entry in &entries[start..end] {
+                            if request.withscores {
+                                result.push(format!("{}:{}", entry.member, entry.value));
+                            } else {
+                                result.push(entry.member.to_string());
+                            }
+                        }
 
-                    remaining -= end - start;
-                    offset = offset.saturating_sub(page.entries.len());
+                        remaining -= end - start;
+                        offset = offset.saturating_sub(entries.len());
+                    }
                 }
             }
         }
@@ -1072,7 +1012,7 @@ mod tests {
             };
 
             let query_start = std::time::Instant::now();
-            let _result = state.zrange("test".to_string(), range_request);
+            let _result = state.zrevrange("test".to_string(), range_request);
             total_query_duration += query_start.elapsed();
         }
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -161,11 +161,11 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_default();
 
         let entry = RankedEntry {
             value: request.value,
-            member: member,
+            member,
             expire: None,
         };
 
@@ -179,19 +179,14 @@ impl RankedState {
 
         let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_default();
 
-        let mut entry = sorted_entries
-            .take(&RankedEntry {
-                value: 0,
-                member: member.clone(),
-                expire: None,
-            })
-            .unwrap_or_else(|| RankedEntry {
-                value: 0,
-                member: member,
-                expire: None,
-            });
+        let entry = RankedEntry {
+            value: 0,
+            member: member.clone(),
+            expire: None,
+        };
+        let mut entry = sorted_entries.take(&entry).unwrap_or(entry);
 
         entry.value += request.increment;
         sorted_entries.insert(entry);
@@ -212,19 +207,15 @@ impl RankedState {
 
         let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
-        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
+        let sorted_entries = tables.entry(table).or_default();
 
-        let mut entry = sorted_entries
-            .take(&RankedEntry {
-                value: 0,
-                member: member.clone(),
-                expire: None,
-            })
-            .unwrap_or_else(|| RankedEntry {
-                value: 0,
-                member: member.clone(),
-                expire: None,
-            });
+        let entry = RankedEntry {
+            value: 0,
+            member: member.clone(),
+            expire: None,
+        };
+
+        let mut entry = sorted_entries.take(&entry).unwrap_or(entry);
 
         entry.value += request.increment;
         entry.expire = Some(now + request.expire);
@@ -232,8 +223,8 @@ impl RankedState {
 
         expire_queue.push(ExpireEntry {
             expire_time: now + request.expire,
-            table_id: table_id,
-            member: member,
+            table_id,
+            member,
             value: request.increment,
         });
 

--- a/violet-backend-core/src/memory.rs
+++ b/violet-backend-core/src/memory.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, BinaryHeap, HashMap};
-use std::sync::{Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedEntry {
     pub value: i64,
-    pub member: String,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub member: Arc<String>,
     pub expire: Option<u64>,
 }
 
@@ -27,7 +28,6 @@ impl PartialOrd for RankedEntry {
 
 impl Ord for RankedEntry {
     fn cmp(&self, other: &Self) -> Ordering {
-        // 값이 같으면 member로 정렬
         match self.value.cmp(&other.value) {
             Ordering::Equal => self.member.cmp(&other.member),
             ordering => ordering,
@@ -39,13 +39,12 @@ impl Ord for RankedEntry {
 struct ExpireEntry {
     expire_time: u64,
     table: String,
-    member: String,
+    member: Arc<String>,
     value: i64,
 }
 
 impl Ord for ExpireEntry {
     fn cmp(&self, other: &Self) -> Ordering {
-        // BinaryHeap은 최대 힙이므로, 시간이 빠른 순서대로 정렬하기 위해 역순으로 비교
         other.expire_time.cmp(&self.expire_time)
     }
 }
@@ -84,7 +83,7 @@ pub struct ZRangeRequest {
 
 #[allow(clippy::type_complexity)]
 pub struct RankedState {
-    tables: RwLock<HashMap<String, (HashMap<String, RankedEntry>, BTreeSet<RankedEntry>)>>,
+    tables: RwLock<HashMap<String, BTreeSet<RankedEntry>>>,
     expire_queue: Mutex<BinaryHeap<ExpireEntry>>,
 }
 
@@ -112,20 +111,19 @@ impl RankedState {
 
             let entry = expire_queue.pop().unwrap();
 
-            if let Some((entries, sorted_entries)) = tables.get_mut(&entry.table) {
-                if let Some(ranked_entry) = entries.get_mut(&entry.member) {
-                    // 정렬된 집합에서 기존 항목 제거
-                    let old_entry = ranked_entry.clone();
-                    sorted_entries.remove(&old_entry);
-
-                    // 값 업데이트
-                    ranked_entry.value -= entry.value;
-
-                    // 값이 0보다 크면 정렬된 집합에 다시 추가
-                    if ranked_entry.value > 0 {
-                        sorted_entries.insert(ranked_entry.clone());
-                    } else {
-                        entries.remove(&entry.member);
+            if let Some(sorted_entries) = tables.get_mut(&entry.table) {
+                if let Some(ranked_entry) = sorted_entries.take(&RankedEntry {
+                    value: entry.value,
+                    member: entry.member.clone(),
+                    expire: None,
+                }) {
+                    let new_value = ranked_entry.value - entry.value;
+                    if new_value > 0 {
+                        sorted_entries.insert(RankedEntry {
+                            value: new_value,
+                            member: ranked_entry.member,
+                            expire: None,
+                        });
                     }
                 }
             }
@@ -135,25 +133,17 @@ impl RankedState {
     pub fn zadd(&self, table: String, request: ZAddRequest) -> String {
         self.process_expired_entries();
 
+        let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let (entries, sorted_entries) = tables
-            .entry(table)
-            .or_insert_with(|| (HashMap::new(), BTreeSet::new()));
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
-        // 기존 항목 수정 또는 새로운 항목 생성
-        let entry = entries
-            .entry(request.member.clone())
-            .or_insert_with(|| RankedEntry {
-                value: 0,
-                member: request.member.clone(),
-                expire: None,
-            });
+        let entry = RankedEntry {
+            value: request.value,
+            member: member,
+            expire: None,
+        };
 
-        // 정렬된 집합에서 항목을 제거하고 다시 삽입해야 올바른 순서가 유지됨
-        // BTreeSet은 값이 변경되면 자동으로 순서를 조정하지 않기 때문에 필수적인 과정임
-        sorted_entries.remove(entry);
-        entry.value = request.value;
-        sorted_entries.insert(entry.clone());
+        sorted_entries.replace(entry);
 
         "OK".to_string()
     }
@@ -161,23 +151,24 @@ impl RankedState {
     pub fn zincrby(&self, table: String, request: ZIncrByRequest) -> String {
         self.process_expired_entries();
 
+        let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
-        let (entries, sorted_entries) = tables
-            .entry(table)
-            .or_insert_with(|| (HashMap::new(), BTreeSet::new()));
+        let sorted_entries = tables.entry(table).or_insert_with(BTreeSet::new);
 
-        // 기존 항목 수정 또는 새로운 항목 생성
-        let entry = entries
-            .entry(request.member.clone())
-            .or_insert_with(|| RankedEntry {
+        let mut entry = sorted_entries
+            .take(&RankedEntry {
                 value: 0,
-                member: request.member.clone(),
+                member: member.clone(),
+                expire: None,
+            })
+            .unwrap_or_else(|| RankedEntry {
+                value: 0,
+                member: member,
                 expire: None,
             });
 
-        sorted_entries.remove(entry);
         entry.value += request.increment;
-        sorted_entries.insert(entry.clone());
+        sorted_entries.insert(entry);
 
         "OK".to_string()
     }
@@ -190,33 +181,31 @@ impl RankedState {
             .unwrap()
             .as_secs();
 
+        let member = Arc::new(request.member);
         let mut tables = self.tables.write().unwrap();
         let mut expire_queue = self.expire_queue.lock().unwrap();
-        let (entries, sorted_entries) = tables
-            .entry(table.clone())
-            .or_insert_with(|| (HashMap::new(), BTreeSet::new()));
+        let sorted_entries = tables.entry(table.clone()).or_insert_with(BTreeSet::new);
 
-        // 기존 항목 제거 (있는 경우)
-        // 기존 항목 수정 또는 새로운 항목 생성
-        let entry = entries
-            .entry(request.member.clone())
-            .or_insert_with(|| RankedEntry {
+        let mut entry = sorted_entries
+            .take(&RankedEntry {
                 value: 0,
-                member: request.member.clone(),
+                member: member.clone(),
+                expire: None,
+            })
+            .unwrap_or_else(|| RankedEntry {
+                value: 0,
+                member: member.clone(),
                 expire: None,
             });
 
-        // 정렬된 집합에서 항목을 제거하고 다시 삽입해야 올바른 순서가 유지됨
-        sorted_entries.remove(entry);
         entry.value += request.increment;
         entry.expire = Some(now + request.expire);
-        sorted_entries.insert(entry.clone());
+        sorted_entries.insert(entry);
 
-        // 만료 큐에 추가
         expire_queue.push(ExpireEntry {
             expire_time: now + request.expire,
-            table: table.clone(),
-            member: request.member.clone(),
+            table: table,
+            member: member,
             value: request.increment,
         });
 
@@ -227,7 +216,7 @@ impl RankedState {
         self.process_expired_entries();
 
         let tables = self.tables.read().unwrap();
-        if let Some((_, sorted_entries)) = tables.get(&table) {
+        if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
                 .iter()
                 .skip(request.offset)
@@ -236,11 +225,10 @@ impl RankedState {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)
                     } else {
-                        entry.member.clone()
+                        entry.member.to_string()
                     }
                 })
                 .collect();
-
             serde_json::to_string(&result).unwrap()
         } else {
             "[]".to_string()
@@ -251,7 +239,7 @@ impl RankedState {
         self.process_expired_entries();
 
         let tables = self.tables.read().unwrap();
-        if let Some((_, sorted_entries)) = tables.get(&table) {
+        if let Some(sorted_entries) = tables.get(&table) {
             let result: Vec<_> = sorted_entries
                 .iter()
                 .rev()
@@ -261,11 +249,10 @@ impl RankedState {
                     if request.withscores {
                         format!("{}:{}", entry.member, entry.value)
                     } else {
-                        entry.member.clone()
+                        entry.member.to_string()
                     }
                 })
                 .collect();
-
             serde_json::to_string(&result).unwrap()
         } else {
             "[]".to_string()
@@ -750,8 +737,8 @@ mod tests {
 
         // 메모리 사용량 확인
         let tables = state.tables.read().unwrap();
-        let (entries, _) = tables.get("test").unwrap();
-        println!("Total entries in memory: {}", entries.len());
+        let sorted_entries = tables.get("test").unwrap();
+        println!("Total entries in memory: {}", sorted_entries.len());
         println!(
             "Memory usage per entry: ~{} bytes",
             std::mem::size_of::<RankedEntry>() + std::mem::size_of::<String>() * 2


### PR DESCRIPTION
- top access

```
Starting stress test with 50000000 entries...

Insertion completed in 135.8405554s
Insertion rate: 368078.59 entries/sec

zrevrange query completed in 8.767µs (average over 100 iterations)
zrevrange query rate: 114064.10 queries/sec

Total entries in memory: 50000000
Memory usage per RankedEntry: ~32 bytes
Memory usage per ExpireEntry: ~32 bytes
Memory optimization: Original ExpireEntry size: ~48 bytes
Memory optimization: Current ExpireEntry size: ~32 bytes
Memory optimization: Saving ~16 bytes per entry
Total memory saved: ~762 MB
Total entries in expire queue: 50000000
Number of unique tables: 1
Memory usage for table management: ~0 KB
```

- random access

```
Starting stress test with 50000000 entries...

Insertion completed in 89.5489589s
Insertion rate: 558353.78 entries/sec

zrange query completed in 42.86083ms (average over 100 iterations)
zrange query rate: 23.33 queries/sec

Total entries in memory: 50000000
Memory usage per RankedEntry: ~32 bytes
Memory usage per ExpireEntry: ~32 bytes
Memory optimization: Original ExpireEntry size: ~48 bytes
Memory optimization: Current ExpireEntry size: ~32 bytes
Memory optimization: Saving ~16 bytes per entry
Total memory saved: ~762 MB
Total entries in expire queue: 50000000
Number of unique tables: 1
Memory usage for table management: ~0 KB
```

- with paging
```
Starting page stress test with 50000000 entries...

Insertion completed in 109.3602173s
Insertion rate: 457204.65 entries/sec

Total pages created: 0

zrevrange query completed in 8.899µs (average over 100 iterations)
zrevrange query rate: 112372.18 queries/sec
Current entries in memory: 50000000
Memory usage per entry: ~32 bytes
Total page file size: 0 MB
```